### PR TITLE
feat: implement MCP server core (entry point, registry, errors, shutdown)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1"
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "zod": "^4.3.6"
       },
       "bin": {
         "gitpride": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "author": "Nikos Anagnostou",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1"
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.15.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,75 @@
  * Exposes non-destructive git commands to AI assistants via the Model Context Protocol.
  */
 
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+import { Logger } from './server/logger.js';
+import { ToolRegistry } from './server/registry.js';
+
 export const SERVER_NAME = 'gitpride';
 export const SERVER_VERSION = '0.1.0';
 
-export async function main() {
-  // Server implementation will be added in Epic 2.
-  // eslint-disable-next-line no-console
-  console.error(`${SERVER_NAME} v${SERVER_VERSION} — server not yet implemented`);
+const log = new Logger('main');
+
+/** Create a configured McpServer instance and its tool registry. */
+export function createServer(): { server: McpServer; registry: ToolRegistry } {
+  const server = new McpServer(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: {} } },
+  );
+  const registry = new ToolRegistry(server);
+  return { server, registry };
+}
+
+/**
+ * Install signal handlers for SIGINT and SIGTERM that close the server
+ * and exit cleanly. Returns a cleanup function that removes the handlers.
+ */
+export function installShutdownHandlers(
+  server: McpServer,
+  exitFn: (code: number) => void = (code) => process.exit(code),
+): () => void {
+  let shuttingDown = false;
+
+  const shutdown = async (signal: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    log.info(`Received ${signal}, shutting down…`);
+    try {
+      await server.close();
+      log.info('Server closed');
+    } catch (err) {
+      log.error('Error during shutdown', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    exitFn(0);
+  };
+
+  const onSigint = () => void shutdown('SIGINT');
+  const onSigterm = () => void shutdown('SIGTERM');
+
+  process.on('SIGINT', onSigint);
+  process.on('SIGTERM', onSigterm);
+
+  return () => {
+    process.removeListener('SIGINT', onSigint);
+    process.removeListener('SIGTERM', onSigterm);
+  };
+}
+
+export async function main(): Promise<void> {
+  log.info(`Starting ${SERVER_NAME} v${SERVER_VERSION}`);
+
+  const { server } = createServer();
+
+  installShutdownHandlers(server);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  log.info('MCP server connected via stdio');
 }
 
 // Run only when executed directly (not imported)
@@ -17,5 +79,8 @@ const isDirectRun =
   import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('index.js');
 
 if (isDirectRun) {
-  main();
+  main().catch((err) => {
+    log.error('Fatal error', { error: err instanceof Error ? err.message : String(err) });
+    process.exit(1);
+  });
 }

--- a/src/server/errors.ts
+++ b/src/server/errors.ts
@@ -1,0 +1,44 @@
+/**
+ * Structured error types and helpers for converting errors into MCP tool results.
+ */
+
+import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+/** Base error for all gitpride-specific errors. */
+export class GitPrideError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'GitPrideError';
+  }
+}
+
+/** Raised when a tool fails during execution. */
+export class ToolExecutionError extends GitPrideError {
+  constructor(toolName: string, message: string, cause?: unknown) {
+    super(`Tool "${toolName}" failed: ${message}`, 'TOOL_EXECUTION_ERROR', cause);
+    this.name = 'ToolExecutionError';
+  }
+}
+
+/** Raised when a requested tool is not found in the registry. */
+export class ToolNotFoundError extends GitPrideError {
+  constructor(toolName: string) {
+    super(`Tool "${toolName}" is not registered`, 'TOOL_NOT_FOUND');
+    this.name = 'ToolNotFoundError';
+  }
+}
+
+/** Convert any error into an MCP CallToolResult with isError: true. */
+export function errorToToolResult(error: unknown): CallToolResult {
+  const message =
+    error instanceof Error ? error.message : typeof error === 'string' ? error : String(error);
+
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -1,0 +1,66 @@
+/**
+ * Structured logger — writes to stderr to keep stdout free for MCP stdio transport.
+ *
+ * Log level is controlled by the `LOG_LEVEL` environment variable
+ * (debug | info | warn | error). Defaults to "info".
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+function resolveLogLevel(): LogLevel {
+  const env = process.env.LOG_LEVEL?.toLowerCase();
+  if (env && env in LEVEL_ORDER) return env as LogLevel;
+  return 'info';
+}
+
+export class Logger {
+  private readonly minLevel: number;
+
+  constructor(
+    private readonly name: string,
+    level?: LogLevel,
+  ) {
+    this.minLevel = LEVEL_ORDER[level ?? resolveLogLevel()];
+  }
+
+  debug(message: string, data?: Record<string, unknown>): void {
+    this.log('debug', message, data);
+  }
+
+  info(message: string, data?: Record<string, unknown>): void {
+    this.log('info', message, data);
+  }
+
+  warn(message: string, data?: Record<string, unknown>): void {
+    this.log('warn', message, data);
+  }
+
+  error(message: string, data?: Record<string, unknown>): void {
+    this.log('error', message, data);
+  }
+
+  private log(level: LogLevel, message: string, data?: Record<string, unknown>): void {
+    if (LEVEL_ORDER[level] < this.minLevel) return;
+
+    const entry: Record<string, unknown> = {
+      timestamp: new Date().toISOString(),
+      level,
+      name: this.name,
+      message,
+    };
+
+    if (data) entry.data = data;
+
+    process.stderr.write(JSON.stringify(entry) + '\n');
+  }
+}
+
+/** Shared root logger for the server. */
+export const logger = new Logger('gitpride');

--- a/src/server/registry.ts
+++ b/src/server/registry.ts
@@ -1,0 +1,96 @@
+/**
+ * Tool registry — register and dispatch MCP tools.
+ *
+ * Wraps McpServer.tool() with a typed ToolDefinition interface so that
+ * future epics can register tools declaratively (e.g. from config).
+ */
+
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  type ZodRawShapeCompat,
+  type ShapeOutput,
+} from '@modelcontextprotocol/sdk/server/zod-compat.js';
+import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { errorToToolResult, ToolExecutionError } from './errors.js';
+import { Logger } from './logger.js';
+
+const log = new Logger('registry');
+
+/**
+ * Describes a tool that can be registered with the MCP server.
+ * The handler receives the validated input args and returns a CallToolResult.
+ */
+export interface ToolDefinition<T extends ZodRawShapeCompat = ZodRawShapeCompat> {
+  name: string;
+  description: string;
+  inputSchema: T;
+  handler: (args: ShapeOutput<T>) => Promise<CallToolResult>;
+}
+
+/**
+ * Manages tool registration and provides a catalog of registered tools.
+ */
+export class ToolRegistry {
+  private readonly registered = new Map<string, ToolDefinition>();
+
+  constructor(private readonly server: McpServer) {}
+
+  /**
+   * Register a single tool definition with the MCP server.
+   * The handler is wrapped with error handling that converts thrown errors
+   * into MCP error results.
+   */
+  register<T extends ZodRawShapeCompat>(definition: ToolDefinition<T>): void {
+    const { name, description, inputSchema, handler } = definition;
+
+    if (this.registered.has(name)) {
+      throw new Error(`Tool "${name}" is already registered`);
+    }
+
+    this.registered.set(name, definition as unknown as ToolDefinition);
+    log.info(`Registering tool: ${name}`);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.server.tool as any)(name, description, inputSchema, async (args: any, _extra: any) => {
+      try {
+        log.debug(`Executing tool: ${name}`, { args: args as Record<string, unknown> });
+        const result = await handler(args);
+        log.debug(`Tool completed: ${name}`, { isError: result.isError ?? false });
+        return result;
+      } catch (err) {
+        log.error(`Tool failed: ${name}`, {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        if (err instanceof ToolExecutionError) {
+          return errorToToolResult(err);
+        }
+        return errorToToolResult(new ToolExecutionError(name, 'Unexpected error', err));
+      }
+    });
+  }
+
+  /**
+   * Register multiple tool definitions at once.
+   */
+  registerAll(definitions: ToolDefinition[]): void {
+    for (const def of definitions) {
+      this.register(def);
+    }
+  }
+
+  /** Names of all currently registered tools. */
+  get toolNames(): string[] {
+    return Array.from(this.registered.keys());
+  }
+
+  /** Number of registered tools. */
+  get size(): number {
+    return this.registered.size;
+  }
+
+  /** Check whether a tool is registered. */
+  has(name: string): boolean {
+    return this.registered.has(name);
+  }
+}

--- a/tests/server/errors.test.ts
+++ b/tests/server/errors.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GitPrideError,
+  ToolExecutionError,
+  ToolNotFoundError,
+  errorToToolResult,
+} from '../../src/server/errors.js';
+
+describe('GitPrideError', () => {
+  it('should store code and message', () => {
+    const err = new GitPrideError('bad thing', 'BAD_THING');
+    expect(err.message).toBe('bad thing');
+    expect(err.code).toBe('BAD_THING');
+    expect(err.name).toBe('GitPrideError');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('should preserve the cause', () => {
+    const cause = new Error('root cause');
+    const err = new GitPrideError('wrapper', 'WRAP', cause);
+    expect(err.cause).toBe(cause);
+  });
+});
+
+describe('ToolExecutionError', () => {
+  it('should include tool name in message', () => {
+    const err = new ToolExecutionError('git_status', 'spawn failed');
+    expect(err.message).toContain('git_status');
+    expect(err.message).toContain('spawn failed');
+    expect(err.code).toBe('TOOL_EXECUTION_ERROR');
+    expect(err.name).toBe('ToolExecutionError');
+  });
+});
+
+describe('ToolNotFoundError', () => {
+  it('should include tool name in message', () => {
+    const err = new ToolNotFoundError('nonexistent');
+    expect(err.message).toContain('nonexistent');
+    expect(err.code).toBe('TOOL_NOT_FOUND');
+  });
+});
+
+describe('errorToToolResult', () => {
+  it('should convert an Error to a tool result with isError: true', () => {
+    const result = errorToToolResult(new Error('boom'));
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([{ type: 'text', text: 'boom' }]);
+  });
+
+  it('should convert a string to a tool result', () => {
+    const result = errorToToolResult('string error');
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toHaveProperty('text', 'string error');
+  });
+
+  it('should convert unknown values to a tool result', () => {
+    const result = errorToToolResult(42);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toHaveProperty('text', '42');
+  });
+});

--- a/tests/server/lifecycle.test.ts
+++ b/tests/server/lifecycle.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  createServer,
+  installShutdownHandlers,
+  SERVER_NAME,
+  SERVER_VERSION,
+} from '../../src/index.js';
+
+// Suppress logger output during tests
+vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+describe('createServer', () => {
+  it('should return a server and registry', () => {
+    const { server, registry } = createServer();
+    expect(server).toBeDefined();
+    expect(registry).toBeDefined();
+    expect(registry.size).toBe(0);
+  });
+});
+
+describe('installShutdownHandlers', () => {
+  afterEach(() => {
+    // Remove any leftover listeners that tests may have added
+    process.removeAllListeners('SIGINT');
+    process.removeAllListeners('SIGTERM');
+  });
+
+  it('should call exitFn(0) on SIGINT', async () => {
+    const { server } = createServer();
+    const exitFn = vi.fn();
+
+    installShutdownHandlers(server, exitFn);
+    process.emit('SIGINT');
+
+    // Allow the async shutdown to complete
+    await new Promise((r) => setTimeout(r, 50));
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+
+  it('should call exitFn(0) on SIGTERM', async () => {
+    const { server } = createServer();
+    const exitFn = vi.fn();
+
+    installShutdownHandlers(server, exitFn);
+    process.emit('SIGTERM');
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+
+  it('should only shut down once on repeated signals', async () => {
+    const { server } = createServer();
+    const exitFn = vi.fn();
+
+    installShutdownHandlers(server, exitFn);
+    process.emit('SIGINT');
+    process.emit('SIGINT');
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(exitFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return a cleanup function that removes handlers', () => {
+    const { server } = createServer();
+    const exitFn = vi.fn();
+
+    const cleanup = installShutdownHandlers(server, exitFn);
+    const beforeCount = process.listenerCount('SIGINT');
+
+    cleanup();
+    const afterCount = process.listenerCount('SIGINT');
+
+    expect(afterCount).toBeLessThan(beforeCount);
+  });
+});
+
+describe('smoke tests (preserved from Epic 1)', () => {
+  it('should export the server name', () => {
+    expect(SERVER_NAME).toBe('gitpride');
+  });
+
+  it('should export a valid semver version', () => {
+    expect(SERVER_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/tests/server/logger.test.ts
+++ b/tests/server/logger.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Logger } from '../../src/server/logger.js';
+
+describe('Logger', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it('should write JSON to stderr', () => {
+    const log = new Logger('test', 'debug');
+    log.info('hello');
+
+    expect(stderrSpy).toHaveBeenCalledOnce();
+
+    const output = stderrSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+
+    expect(parsed).toMatchObject({
+      level: 'info',
+      name: 'test',
+      message: 'hello',
+    });
+    expect(parsed.timestamp).toBeDefined();
+  });
+
+  it('should include data when provided', () => {
+    const log = new Logger('test', 'debug');
+    log.warn('oops', { key: 'value' });
+
+    const output = stderrSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+
+    expect(parsed.data).toEqual({ key: 'value' });
+  });
+
+  it('should suppress messages below the configured level', () => {
+    const log = new Logger('test', 'error');
+    log.debug('ignored');
+    log.info('ignored');
+    log.warn('ignored');
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+
+    log.error('shown');
+    expect(stderrSpy).toHaveBeenCalledOnce();
+  });
+
+  it('should support all log levels', () => {
+    const log = new Logger('test', 'debug');
+
+    log.debug('d');
+    log.info('i');
+    log.warn('w');
+    log.error('e');
+
+    expect(stderrSpy).toHaveBeenCalledTimes(4);
+
+    const levels = stderrSpy.mock.calls.map((c) => JSON.parse(c[0] as string).level);
+    expect(levels).toEqual(['debug', 'info', 'warn', 'error']);
+  });
+
+  it('should default to info level when LOG_LEVEL is unset', () => {
+    const original = process.env.LOG_LEVEL;
+    delete process.env.LOG_LEVEL;
+    try {
+      const log = new Logger('test');
+      log.debug('ignored');
+      expect(stderrSpy).not.toHaveBeenCalled();
+
+      log.info('shown');
+      expect(stderrSpy).toHaveBeenCalledOnce();
+    } finally {
+      if (original !== undefined) process.env.LOG_LEVEL = original;
+    }
+  });
+});

--- a/tests/server/registry.test.ts
+++ b/tests/server/registry.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import { ToolRegistry } from '../../src/server/registry.js';
+
+// Suppress logger output during tests
+vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+function makeServer(): McpServer {
+  return new McpServer({ name: 'test-server', version: '0.0.1' }, { capabilities: { tools: {} } });
+}
+
+describe('ToolRegistry', () => {
+  let server: McpServer;
+  let registry: ToolRegistry;
+
+  beforeEach(() => {
+    server = makeServer();
+    registry = new ToolRegistry(server);
+  });
+
+  it('should register a tool and track it', () => {
+    registry.register({
+      name: 'echo',
+      description: 'Echo input back',
+      inputSchema: { text: z.string() },
+      handler: async ({ text }) => ({
+        content: [{ type: 'text', text }],
+      }),
+    });
+
+    expect(registry.has('echo')).toBe(true);
+    expect(registry.size).toBe(1);
+    expect(registry.toolNames).toEqual(['echo']);
+  });
+
+  it('should reject duplicate tool names', () => {
+    const def = {
+      name: 'dup',
+      description: 'Duplicate',
+      inputSchema: {},
+      handler: async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }),
+    };
+    registry.register(def);
+    expect(() => registry.register(def)).toThrow(/already registered/);
+  });
+
+  it('should register multiple tools via registerAll', () => {
+    registry.registerAll([
+      {
+        name: 'a',
+        description: 'A',
+        inputSchema: {},
+        handler: async () => ({ content: [{ type: 'text' as const, text: 'a' }] }),
+      },
+      {
+        name: 'b',
+        description: 'B',
+        inputSchema: {},
+        handler: async () => ({ content: [{ type: 'text' as const, text: 'b' }] }),
+      },
+    ]);
+    expect(registry.size).toBe(2);
+    expect(registry.has('a')).toBe(true);
+    expect(registry.has('b')).toBe(true);
+  });
+
+  it('should report false for unregistered tools', () => {
+    expect(registry.has('nonexistent')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the MCP Server Core epic — the full protocol layer needed for AI clients to connect via stdio.

### Changes

- **Entry point** (`src/index.ts`): Creates `McpServer` with stdio transport, connects and runs
- **Tool registry** (`src/server/registry.ts`): Typed `ToolDefinition` interface with error-wrapping dispatch
- **Structured logging** (`src/server/logger.ts`): JSON to stderr, configurable via `LOG_LEVEL` env var
- **Error handling** (`src/server/errors.ts`): `GitPrideError`, `ToolExecutionError`, `ToolNotFoundError`, `errorToToolResult()` helper
- **Graceful shutdown**: SIGINT/SIGTERM handlers with idempotent guard, clean exit code 0
- **25 tests** covering logger, errors, registry, lifecycle, and existing smoke tests

### Testing

```
npm run build        # clean
npm run test         # 25/25 pass
npm run lint         # clean
npm run format:check # clean
```

Fixes #8
