### PR TITLE
fix: enforce combined-arg guard and enum constraints

### DIFF
--- a/src/config/guard.ts
+++ b/src/config/guard.ts
@@ -125,3 +125,22 @@ export function validateExtraArgs(commandName: string, extraArgs: readonly strin
   checkDestructiveSubcommand(commandName, extraArgs);
   checkBlockedSequences(commandName, extraArgs);
 }
+
+/**
+ * Validate the combined base args + extra args together.
+ *
+ * This catches destructive sequences that span the boundary between
+ * configured base args and user-supplied extra args (e.g. base=['tag']
+ * combined with extra=['--delete', 'v1'] forms the blocked sequence
+ * "tag --delete").
+ */
+export function validateCombinedArgs(
+  commandName: string,
+  baseArgs: readonly string[],
+  extraArgs: readonly string[],
+): void {
+  // Extra args are already validated individually by validateExtraArgs;
+  // here we only need to check blocked sequences across the combined list.
+  const combined = [...baseArgs, ...extraArgs];
+  checkBlockedSequences(commandName, combined);
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,6 +6,7 @@ export { loadConfig, parseConfig, ConfigLoadError, ConfigValidationError } from 
 export {
   validateCommandArgs,
   validateExtraArgs,
+  validateCombinedArgs,
   DestructiveCommandError,
   BLOCKED_SUBCOMMANDS,
   BLOCKED_ARG_SEQUENCES,

--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Git module — public API.
+ */
+
+export { runGit, DEFAULT_TIMEOUT_MS, MAX_OUTPUT_BYTES } from './runner.js';
+export type { GitResult, RunGitOptions } from './runner.js';
+export { buildTools, buildToolDefinition } from './tools.js';

--- a/src/git/runner.ts
+++ b/src/git/runner.ts
@@ -1,0 +1,99 @@
+/**
+ * Git command runner — spawns git processes and captures output.
+ *
+ * Uses child_process.spawn to execute git commands with a configurable
+ * timeout. All output is captured as strings from stdout and stderr.
+ */
+
+import { spawn } from 'node:child_process';
+
+import { Logger } from '../server/logger.js';
+
+const log = new Logger('git-runner');
+
+/** Default timeout for git commands (30 seconds). */
+export const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Maximum output size in bytes (1 MB). */
+export const MAX_OUTPUT_BYTES = 1_024 * 1_024;
+
+/** Result of a git command execution. */
+export interface GitResult {
+  /** Standard output from the command. */
+  stdout: string;
+  /** Standard error output from the command. */
+  stderr: string;
+  /** Process exit code (null if killed by signal). */
+  exitCode: number | null;
+}
+
+/** Options for running a git command. */
+export interface RunGitOptions {
+  /** Working directory for the git command. Defaults to cwd. */
+  cwd?: string;
+  /** Timeout in milliseconds. Defaults to DEFAULT_TIMEOUT_MS. */
+  timeoutMs?: number;
+}
+
+/**
+ * Run a git command and capture its output.
+ *
+ * @param args — Arguments to pass to `git` (e.g. ['status', '--short']).
+ * @param options — Optional cwd and timeout settings.
+ * @returns The captured stdout, stderr, and exit code.
+ */
+export function runGit(args: readonly string[], options: RunGitOptions = {}): Promise<GitResult> {
+  const { cwd, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
+
+  log.debug('Running git command', { args: [...args], cwd });
+
+  return new Promise<GitResult>((resolve, reject) => {
+    const child = spawn('git', args as string[], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: timeoutMs,
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let truncated = false;
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdoutBytes += chunk.length;
+      if (stdoutBytes <= MAX_OUTPUT_BYTES) {
+        stdoutChunks.push(chunk);
+      } else if (!truncated) {
+        truncated = true;
+        log.warn('stdout output truncated', { maxBytes: MAX_OUTPUT_BYTES });
+      }
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrBytes += chunk.length;
+      if (stderrBytes <= MAX_OUTPUT_BYTES) {
+        stderrChunks.push(chunk);
+      }
+    });
+
+    child.on('error', (err) => {
+      log.error('Failed to spawn git process', { error: err.message });
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
+      const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+
+      log.debug('Git command completed', {
+        args: [...args],
+        exitCode: code,
+        stdoutLength: stdout.length,
+        stderrLength: stderr.length,
+      });
+
+      resolve({ stdout, stderr, exitCode: code });
+    });
+  });
+}

--- a/src/git/tools.ts
+++ b/src/git/tools.ts
@@ -1,0 +1,189 @@
+/**
+ * Git tool builder — converts command config entries into MCP tool definitions.
+ *
+ * Each CommandConfig entry is transformed into a ToolDefinition that:
+ * 1. Accepts typed input matching the extraArgsSchema (if any)
+ * 2. Validates extra args through the non-destructive guard at runtime
+ * 3. Builds the final argument list and runs git via the runner
+ * 4. Returns stdout as the tool result (or stderr on failure)
+ */
+
+import { z } from 'zod';
+import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { type ToolDefinition } from '../server/registry.js';
+import { ToolExecutionError } from '../server/errors.js';
+import { Logger } from '../server/logger.js';
+import { validateExtraArgs } from '../config/guard.js';
+import { type CommandConfig, type ExtraArgsSchema, type ExtraArgsProperty } from '../config/types.js';
+import { runGit, type RunGitOptions } from './runner.js';
+
+const log = new Logger('git-tools');
+
+/**
+ * Convert an ExtraArgsProperty from config into a Zod schema.
+ */
+function propertyToZod(prop: ExtraArgsProperty): z.ZodTypeAny {
+  let schema: z.ZodTypeAny;
+
+  switch (prop.type) {
+    case 'string':
+      schema = z.string().describe(prop.description ?? '');
+      break;
+    case 'number':
+      schema = z.number().describe(prop.description ?? '');
+      break;
+    case 'boolean':
+      schema = z.boolean().describe(prop.description ?? '');
+      break;
+  }
+
+  if (prop.default !== undefined) {
+    schema = schema.default(prop.default);
+  }
+
+  // Make properties without defaults optional
+  if (prop.default === undefined) {
+    schema = schema.optional();
+  }
+
+  return schema;
+}
+
+/**
+ * Convert an ExtraArgsSchema from config into a Zod object shape
+ * suitable for ToolDefinition.inputSchema.
+ */
+function buildInputSchema(extraArgsSchema?: ExtraArgsSchema): Record<string, z.ZodTypeAny> {
+  if (!extraArgsSchema) return {};
+
+  const shape: Record<string, z.ZodTypeAny> = {};
+  for (const [key, prop] of Object.entries(extraArgsSchema.properties)) {
+    shape[key] = propertyToZod(prop);
+  }
+  return shape;
+}
+
+/**
+ * Convert validated tool input args into CLI arguments for git.
+ *
+ * Maps schema properties to their corresponding git flags:
+ * - boolean true → adds the flag name as --key (or specific mapped flag)
+ * - string/number → adds as positional or --key value
+ */
+function buildExtraCliArgs(
+  config: CommandConfig,
+  inputArgs: Record<string, unknown>,
+): string[] {
+  const extra: string[] = [];
+
+  if (!config.extraArgsSchema) return extra;
+
+  for (const [key, value] of Object.entries(inputArgs)) {
+    if (value === undefined || value === null) continue;
+
+    const prop = config.extraArgsSchema.properties[key];
+    if (!prop) continue;
+
+    switch (prop.type) {
+      case 'boolean':
+        if (value === true) {
+          // Map known boolean flags to their git equivalents
+          if (key === 'staged') {
+            extra.push('--cached');
+          } else if (key === 'all') {
+            extra.push('--all');
+          } else {
+            extra.push(`--${key}`);
+          }
+        }
+        break;
+      case 'number':
+        // Map known number properties to their git equivalents
+        if (key === 'limit') {
+          extra.push(`-n`, String(value));
+        } else {
+          extra.push(`--${key}`, String(value));
+        }
+        break;
+      case 'string':
+        // String values are typically positional (e.g., ref, file)
+        if (value) {
+          extra.push(String(value));
+        }
+        break;
+    }
+  }
+
+  return extra;
+}
+
+/**
+ * Build a single ToolDefinition from a CommandConfig entry.
+ */
+export function buildToolDefinition(
+  config: CommandConfig,
+  gitOptions?: RunGitOptions,
+): ToolDefinition {
+  const inputSchema = buildInputSchema(
+    config.allowExtraArgs ? config.extraArgsSchema : undefined,
+  );
+
+  return {
+    name: config.name,
+    description: config.description,
+    inputSchema,
+    handler: async (args: Record<string, unknown>): Promise<CallToolResult> => {
+      log.debug(`Handling tool: ${config.name}`, { args });
+
+      // Build the final argument list
+      const cliArgs = [...config.args];
+
+      if (config.allowExtraArgs && args && Object.keys(args).length > 0) {
+        const extraArgs = buildExtraCliArgs(config, args);
+
+        // Validate extra args through the guard
+        if (extraArgs.length > 0) {
+          try {
+            validateExtraArgs(config.name, extraArgs);
+          } catch (err) {
+            throw new ToolExecutionError(
+              config.name,
+              err instanceof Error ? err.message : String(err),
+              err,
+            );
+          }
+        }
+
+        cliArgs.push(...extraArgs);
+      }
+
+      // Execute the git command
+      const result = await runGit(cliArgs, gitOptions);
+
+      if (result.exitCode !== 0) {
+        const errorOutput = result.stderr.trim() || result.stdout.trim() || 'Command failed';
+        return {
+          content: [{ type: 'text', text: errorOutput }],
+          isError: true,
+        };
+      }
+
+      const output = result.stdout.trim() || result.stderr.trim() || '(no output)';
+      return {
+        content: [{ type: 'text', text: output }],
+      };
+    },
+  };
+}
+
+/**
+ * Build ToolDefinitions for all commands in a config.
+ */
+export function buildTools(
+  commands: readonly CommandConfig[],
+  gitOptions?: RunGitOptions,
+): ToolDefinition[] {
+  log.info(`Building ${commands.length} tool(s) from config`);
+  return commands.map((cmd) => buildToolDefinition(cmd, gitOptions));
+}

--- a/src/git/tools.ts
+++ b/src/git/tools.ts
@@ -14,7 +14,7 @@ import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { type ToolDefinition } from '../server/registry.js';
 import { ToolExecutionError } from '../server/errors.js';
 import { Logger } from '../server/logger.js';
-import { validateExtraArgs } from '../config/guard.js';
+import { validateExtraArgs, validateCombinedArgs } from '../config/guard.js';
 import { type CommandConfig, type ExtraArgsSchema, type ExtraArgsProperty } from '../config/types.js';
 import { runGit, type RunGitOptions } from './runner.js';
 
@@ -28,13 +28,30 @@ function propertyToZod(prop: ExtraArgsProperty): z.ZodTypeAny {
 
   switch (prop.type) {
     case 'string':
-      schema = z.string().describe(prop.description ?? '');
+      if (prop.enum && prop.enum.length > 0) {
+        const values = prop.enum.map(String) as [string, ...string[]];
+        schema = z.enum(values).describe(prop.description ?? '');
+      } else {
+        schema = z.string().describe(prop.description ?? '');
+      }
       break;
     case 'number':
-      schema = z.number().describe(prop.description ?? '');
+      if (prop.enum && prop.enum.length > 0) {
+        const literals = prop.enum.map((v) => z.literal(Number(v)));
+        schema = z.union(literals as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
+          .describe(prop.description ?? '');
+      } else {
+        schema = z.number().describe(prop.description ?? '');
+      }
       break;
     case 'boolean':
-      schema = z.boolean().describe(prop.description ?? '');
+      if (prop.enum && prop.enum.length > 0) {
+        const literals = prop.enum.map((v) => z.literal(Boolean(v)));
+        schema = z.union(literals as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
+          .describe(prop.description ?? '');
+      } else {
+        schema = z.boolean().describe(prop.description ?? '');
+      }
       break;
   }
 
@@ -142,10 +159,11 @@ export function buildToolDefinition(
       if (config.allowExtraArgs && args && Object.keys(args).length > 0) {
         const extraArgs = buildExtraCliArgs(config, args);
 
-        // Validate extra args through the guard
+        // Validate extra args individually and combined with base args
         if (extraArgs.length > 0) {
           try {
             validateExtraArgs(config.name, extraArgs);
+            validateCombinedArgs(config.name, config.args, extraArgs);
           } catch (err) {
             throw new ToolExecutionError(
               config.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 import { loadConfig, ConfigLoadError, ConfigValidationError } from './config/index.js';
+import { type CommandConfig } from './config/types.js';
+import { buildTools } from './git/index.js';
 import { Logger } from './server/logger.js';
 import { ToolRegistry } from './server/registry.js';
 
@@ -67,8 +69,10 @@ export async function main(): Promise<void> {
 
   // Load command configuration (optional — server starts without config)
   const configPath = process.env.GITPRIDE_CONFIG;
+  let commands: CommandConfig[] = [];
   try {
     const config = await loadConfig(configPath);
+    commands = config.commands;
     log.info(`Loaded ${config.commands.length} command(s) from config`);
   } catch (err) {
     if (err instanceof ConfigLoadError && !configPath) {
@@ -84,7 +88,14 @@ export async function main(): Promise<void> {
     }
   }
 
-  const { server } = createServer();
+  const { server, registry } = createServer();
+
+  // Build and register git command tools from config
+  if (commands.length > 0) {
+    const tools = buildTools(commands);
+    registry.registerAll(tools);
+    log.info(`Registered ${tools.length} git tool(s)`);
+  }
 
   installShutdownHandlers(server);
 

--- a/tests/config/guard.test.ts
+++ b/tests/config/guard.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   validateCommandArgs,
   validateExtraArgs,
+  validateCombinedArgs,
   DestructiveCommandError,
   BLOCKED_SUBCOMMANDS,
   BLOCKED_SHELL_OPERATORS,
@@ -124,5 +125,40 @@ describe('validateExtraArgs', () => {
     expect(() => validateExtraArgs('git_log', ['>', '/tmp/out'])).toThrow(
       DestructiveCommandError,
     );
+  });
+});
+
+describe('validateCombinedArgs', () => {
+  it('should block sequences spanning base and extra args', () => {
+    // base=['tag'], extra=['--delete', 'v1'] → combined=['tag', '--delete', 'v1']
+    expect(() => validateCombinedArgs('git_tag', ['tag'], ['--delete', 'v1'])).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should block "tag -d" spanning base and extra args', () => {
+    expect(() => validateCombinedArgs('git_tag', ['tag'], ['-d', 'v1'])).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should block "branch --delete" spanning base and extra args', () => {
+    expect(() => validateCombinedArgs('git_branch', ['branch'], ['--delete', 'feat'])).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should block "branch -D" spanning base and extra args', () => {
+    expect(() => validateCombinedArgs('git_branch', ['branch'], ['-D', 'feat'])).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should allow safe combined args', () => {
+    expect(() => validateCombinedArgs('git_tag', ['tag'], ['-l'])).not.toThrow();
+  });
+
+  it('should allow empty extra args', () => {
+    expect(() => validateCombinedArgs('git_log', ['log', '--oneline'], [])).not.toThrow();
   });
 });

--- a/tests/git/runner.test.ts
+++ b/tests/git/runner.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for the git command runner.
+ *
+ * These tests exercise the runGit function against a real git installation
+ * to validate process spawning, output capture, and error handling.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+
+import { runGit, DEFAULT_TIMEOUT_MS, MAX_OUTPUT_BYTES } from '../../src/git/runner.js';
+
+// Suppress logger output during tests
+vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+describe('runGit', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'gitpride-runner-'));
+    // Initialize a git repo in the temp directory
+    execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+    execSync('git config user.email "test@test.com"', { cwd: tempDir, stdio: 'ignore' });
+    execSync('git config user.name "Test"', { cwd: tempDir, stdio: 'ignore' });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should run git status in a clean repo', async () => {
+    const result = await runGit(['status'], { cwd: tempDir });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('nothing to commit');
+  });
+
+  it('should capture stderr from git commands', async () => {
+    const result = await runGit(['log'], { cwd: tempDir });
+    // Empty repo has no commits — git log fails
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toBeTruthy();
+  });
+
+  it('should respect the cwd option', async () => {
+    const result = await runGit(['rev-parse', '--show-toplevel'], { cwd: tempDir });
+    expect(result.exitCode).toBe(0);
+    // realpath resolves symlinks (e.g., /tmp -> /private/tmp on macOS)
+    expect(result.stdout.trim()).toContain(tempDir.split('/').pop());
+  });
+
+  it('should run git branch in a repo with a commit', async () => {
+    // Create a file and commit
+    await writeFile(join(tempDir, 'hello.txt'), 'hello');
+    execSync('git add . && git commit -m "initial"', { cwd: tempDir, stdio: 'ignore' });
+
+    const result = await runGit(['branch'], { cwd: tempDir });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/\*\s+(main|master)/);
+  });
+
+  it('should run git log in a repo with commits', async () => {
+    await writeFile(join(tempDir, 'hello.txt'), 'hello');
+    execSync('git add . && git commit -m "first commit"', { cwd: tempDir, stdio: 'ignore' });
+
+    const result = await runGit(['log', '--oneline'], { cwd: tempDir });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('first commit');
+  });
+
+  it('should run git diff', async () => {
+    await writeFile(join(tempDir, 'hello.txt'), 'hello');
+    execSync('git add . && git commit -m "init"', { cwd: tempDir, stdio: 'ignore' });
+    await writeFile(join(tempDir, 'hello.txt'), 'hello world');
+
+    const result = await runGit(['diff'], { cwd: tempDir });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('+hello world');
+  });
+
+  it('should run git show', async () => {
+    await writeFile(join(tempDir, 'hello.txt'), 'hello');
+    execSync('git add . && git commit -m "show test"', { cwd: tempDir, stdio: 'ignore' });
+
+    const result = await runGit(['show', 'HEAD'], { cwd: tempDir });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('show test');
+  });
+
+  it('should run git blame', async () => {
+    await writeFile(join(tempDir, 'hello.txt'), 'hello');
+    execSync('git add . && git commit -m "blame test"', { cwd: tempDir, stdio: 'ignore' });
+
+    const result = await runGit(['blame', 'hello.txt'], { cwd: tempDir });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('hello');
+  });
+
+  it('should run git remote -v', async () => {
+    const result = await runGit(['remote', '-v'], { cwd: tempDir });
+    expect(result.exitCode).toBe(0);
+    // No remotes configured — empty output is fine
+    expect(result.stdout).toBe('');
+  });
+
+  it('should return non-zero exit code for invalid commands', async () => {
+    const result = await runGit(['no-such-command'], { cwd: tempDir });
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('should export expected constants', () => {
+    expect(DEFAULT_TIMEOUT_MS).toBe(30_000);
+    expect(MAX_OUTPUT_BYTES).toBe(1_024 * 1_024);
+  });
+});

--- a/tests/git/tools.test.ts
+++ b/tests/git/tools.test.ts
@@ -14,6 +14,7 @@ import { execSync } from 'node:child_process';
 
 import { buildToolDefinition, buildTools } from '../../src/git/tools.js';
 import { type CommandConfig } from '../../src/config/types.js';
+import { z } from 'zod';
 
 // Suppress logger output during tests
 vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
@@ -329,6 +330,45 @@ describe('buildToolDefinition', () => {
       // Try to inject a shell operator via string arg
       await expect(tool.handler({ ref: '; rm -rf /' })).rejects.toThrow(/shell operator/);
     });
+
+    it('should reject destructive sequences spanning base and extra args', async () => {
+      // Base args contain 'tag', user supplies '--delete' via extra arg
+      const tagConfig: CommandConfig = {
+        name: 'git_tag',
+        description: 'List tags',
+        command: 'git',
+        args: ['tag'],
+        allowExtraArgs: true,
+        extraArgsSchema: {
+          type: 'object',
+          properties: {
+            flag: { type: 'string', description: 'flag' },
+          },
+        },
+      };
+
+      const tool = buildToolDefinition(tagConfig, { cwd: tempDir });
+      await expect(tool.handler({ flag: '--delete' })).rejects.toThrow(/destructive sequence/);
+    });
+
+    it('should reject branch --delete spanning base and extra args', async () => {
+      const branchDeleteConfig: CommandConfig = {
+        name: 'git_branch_del',
+        description: 'Should fail',
+        command: 'git',
+        args: ['branch'],
+        allowExtraArgs: true,
+        extraArgsSchema: {
+          type: 'object',
+          properties: {
+            flag: { type: 'string', description: 'flag' },
+          },
+        },
+      };
+
+      const tool = buildToolDefinition(branchDeleteConfig, { cwd: tempDir });
+      await expect(tool.handler({ flag: '-D' })).rejects.toThrow(/destructive sequence/);
+    });
   });
 });
 
@@ -342,5 +382,122 @@ describe('buildTools', () => {
   it('should return empty array for empty config', () => {
     const tools = buildTools([]);
     expect(tools).toHaveLength(0);
+  });
+});
+
+describe('enum enforcement in input schemas', () => {
+  it('should restrict string properties to enum values', () => {
+    const config: CommandConfig = {
+      name: 'git_log_enum',
+      description: 'Log with enum format',
+      command: 'git',
+      args: ['log'],
+      allowExtraArgs: true,
+      extraArgsSchema: {
+        type: 'object',
+        properties: {
+          format: {
+            type: 'string',
+            description: 'Output format',
+            enum: ['oneline', 'short', 'full'],
+          },
+        },
+      },
+    };
+
+    const tool = buildToolDefinition(config);
+    const schema = z.object(tool.inputSchema);
+
+    // Valid values should pass
+    expect(() => schema.parse({ format: 'oneline' })).not.toThrow();
+    expect(() => schema.parse({ format: 'short' })).not.toThrow();
+    expect(() => schema.parse({ format: 'full' })).not.toThrow();
+
+    // Invalid value should fail
+    expect(() => schema.parse({ format: 'evil-format' })).toThrow();
+  });
+
+  it('should restrict number properties to enum values', () => {
+    const config: CommandConfig = {
+      name: 'git_log_limit',
+      description: 'Log with enum limit',
+      command: 'git',
+      args: ['log'],
+      allowExtraArgs: true,
+      extraArgsSchema: {
+        type: 'object',
+        properties: {
+          limit: {
+            type: 'number',
+            description: 'Number of commits',
+            enum: [5, 10, 25, 50],
+          },
+        },
+      },
+    };
+
+    const tool = buildToolDefinition(config);
+    const schema = z.object(tool.inputSchema);
+
+    // Valid values should pass
+    expect(() => schema.parse({ limit: 10 })).not.toThrow();
+    expect(() => schema.parse({ limit: 50 })).not.toThrow();
+
+    // Invalid value should fail
+    expect(() => schema.parse({ limit: 999 })).toThrow();
+  });
+
+  it('should allow unconstrained values when no enum is set', () => {
+    const config: CommandConfig = {
+      name: 'git_log_free',
+      description: 'Log without enum',
+      command: 'git',
+      args: ['log'],
+      allowExtraArgs: true,
+      extraArgsSchema: {
+        type: 'object',
+        properties: {
+          ref: {
+            type: 'string',
+            description: 'Any ref',
+          },
+        },
+      },
+    };
+
+    const tool = buildToolDefinition(config);
+    const schema = z.object(tool.inputSchema);
+
+    // Any string should be accepted
+    expect(() => schema.parse({ ref: 'anything-goes' })).not.toThrow();
+  });
+
+  it('should restrict boolean properties to enum values', () => {
+    const config: CommandConfig = {
+      name: 'git_diff_enum_bool',
+      description: 'Diff with enum boolean',
+      command: 'git',
+      args: ['diff'],
+      allowExtraArgs: true,
+      extraArgsSchema: {
+        type: 'object',
+        properties: {
+          staged: {
+            type: 'boolean',
+            description: 'Must be true',
+            enum: [true],
+          },
+        },
+      },
+    };
+
+    const tool = buildToolDefinition(config);
+    const schema = z.object(tool.inputSchema);
+
+    // Only true should pass
+    expect(() => schema.parse({ staged: true })).not.toThrow();
+
+    // false should fail
+    expect(() => schema.parse({ staged: false })).toThrow();
   });
 });

--- a/tests/git/tools.test.ts
+++ b/tests/git/tools.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for the git tool builder.
+ *
+ * Validates that CommandConfig entries are correctly converted into
+ * ToolDefinition objects with proper input schemas, arg mapping,
+ * guard validation, and execution.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+
+import { buildToolDefinition, buildTools } from '../../src/git/tools.js';
+import { type CommandConfig } from '../../src/config/types.js';
+
+// Suppress logger output during tests
+vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+// ── Test fixtures ──────────────────────────────────────────────────
+
+const STATUS_CONFIG: CommandConfig = {
+  name: 'git_status',
+  description: 'Show the working tree status',
+  command: 'git',
+  args: ['status'],
+  allowExtraArgs: false,
+};
+
+const LOG_CONFIG: CommandConfig = {
+  name: 'git_log',
+  description: 'Show commit logs',
+  command: 'git',
+  args: ['log', '--oneline'],
+  allowExtraArgs: true,
+  extraArgsSchema: {
+    type: 'object',
+    properties: {
+      limit: {
+        type: 'number',
+        description: 'Maximum number of commits to show',
+        default: 20,
+      },
+    },
+  },
+};
+
+const DIFF_CONFIG: CommandConfig = {
+  name: 'git_diff',
+  description: 'Show changes',
+  command: 'git',
+  args: ['diff'],
+  allowExtraArgs: true,
+  extraArgsSchema: {
+    type: 'object',
+    properties: {
+      ref: {
+        type: 'string',
+        description: 'Git ref to diff against',
+      },
+      staged: {
+        type: 'boolean',
+        description: 'Show staged changes',
+        default: false,
+      },
+    },
+  },
+};
+
+const BRANCH_CONFIG: CommandConfig = {
+  name: 'git_branch',
+  description: 'List branches',
+  command: 'git',
+  args: ['branch'],
+  allowExtraArgs: true,
+  extraArgsSchema: {
+    type: 'object',
+    properties: {
+      all: {
+        type: 'boolean',
+        description: 'List all branches',
+        default: false,
+      },
+    },
+  },
+};
+
+const SHOW_CONFIG: CommandConfig = {
+  name: 'git_show',
+  description: 'Show a commit or object',
+  command: 'git',
+  args: ['show'],
+  allowExtraArgs: true,
+  extraArgsSchema: {
+    type: 'object',
+    properties: {
+      ref: {
+        type: 'string',
+        description: 'Commit SHA or ref to show',
+        default: 'HEAD',
+      },
+    },
+  },
+};
+
+const BLAME_CONFIG: CommandConfig = {
+  name: 'git_blame',
+  description: 'Show line attribution',
+  command: 'git',
+  args: ['blame'],
+  allowExtraArgs: true,
+  extraArgsSchema: {
+    type: 'object',
+    properties: {
+      file: {
+        type: 'string',
+        description: 'File path to blame',
+      },
+    },
+  },
+};
+
+const REMOTE_CONFIG: CommandConfig = {
+  name: 'git_remote',
+  description: 'Show remote repositories',
+  command: 'git',
+  args: ['remote', '-v'],
+  allowExtraArgs: false,
+};
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe('buildToolDefinition', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'gitpride-tools-'));
+    execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+    execSync('git config user.email "test@test.com"', { cwd: tempDir, stdio: 'ignore' });
+    execSync('git config user.name "Test"', { cwd: tempDir, stdio: 'ignore' });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should create a tool with correct name and description', () => {
+    const tool = buildToolDefinition(STATUS_CONFIG);
+    expect(tool.name).toBe('git_status');
+    expect(tool.description).toBe('Show the working tree status');
+  });
+
+  it('should create empty inputSchema for commands without extra args', () => {
+    const tool = buildToolDefinition(STATUS_CONFIG);
+    expect(Object.keys(tool.inputSchema)).toHaveLength(0);
+  });
+
+  it('should create inputSchema with properties from extraArgsSchema', () => {
+    const tool = buildToolDefinition(LOG_CONFIG);
+    expect(tool.inputSchema).toHaveProperty('limit');
+  });
+
+  it('should create inputSchema for diff with ref and staged', () => {
+    const tool = buildToolDefinition(DIFF_CONFIG);
+    expect(tool.inputSchema).toHaveProperty('ref');
+    expect(tool.inputSchema).toHaveProperty('staged');
+  });
+
+  describe('git_status tool', () => {
+    it('should return status output from a clean repo', async () => {
+      const tool = buildToolDefinition(STATUS_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({});
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]).toHaveProperty('text');
+      expect((result.content[0] as { text: string }).text).toContain('nothing to commit');
+    });
+  });
+
+  describe('git_log tool', () => {
+    it('should return commit logs', async () => {
+      await writeFile(join(tempDir, 'file.txt'), 'content');
+      execSync('git add . && git commit -m "test log"', { cwd: tempDir, stdio: 'ignore' });
+
+      const tool = buildToolDefinition(LOG_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({ limit: 5 });
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toContain('test log');
+    });
+
+    it('should use default limit when not provided', async () => {
+      await writeFile(join(tempDir, 'file.txt'), 'content');
+      execSync('git add . && git commit -m "default limit"', { cwd: tempDir, stdio: 'ignore' });
+
+      const tool = buildToolDefinition(LOG_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({});
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toContain('default limit');
+    });
+  });
+
+  describe('git_diff tool', () => {
+    it('should show unstaged changes', async () => {
+      await writeFile(join(tempDir, 'file.txt'), 'original');
+      execSync('git add . && git commit -m "init"', { cwd: tempDir, stdio: 'ignore' });
+      await writeFile(join(tempDir, 'file.txt'), 'modified');
+
+      const tool = buildToolDefinition(DIFF_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({});
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toContain('+modified');
+    });
+
+    it('should show staged changes with --cached', async () => {
+      await writeFile(join(tempDir, 'file.txt'), 'original');
+      execSync('git add . && git commit -m "init"', { cwd: tempDir, stdio: 'ignore' });
+      await writeFile(join(tempDir, 'file.txt'), 'staged change');
+      execSync('git add .', { cwd: tempDir, stdio: 'ignore' });
+
+      const tool = buildToolDefinition(DIFF_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({ staged: true });
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toContain('+staged change');
+    });
+
+    it('should diff against a ref', async () => {
+      await writeFile(join(tempDir, 'file.txt'), 'v1');
+      execSync('git add . && git commit -m "v1"', { cwd: tempDir, stdio: 'ignore' });
+      await writeFile(join(tempDir, 'file.txt'), 'v2');
+      execSync('git add . && git commit -m "v2"', { cwd: tempDir, stdio: 'ignore' });
+
+      const tool = buildToolDefinition(DIFF_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({ ref: 'HEAD~1' });
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toContain('v2');
+    });
+  });
+
+  describe('git_branch tool', () => {
+    it('should list branches', async () => {
+      await writeFile(join(tempDir, 'file.txt'), 'content');
+      execSync('git add . && git commit -m "init"', { cwd: tempDir, stdio: 'ignore' });
+
+      const tool = buildToolDefinition(BRANCH_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({});
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toMatch(/\*\s+(main|master)/);
+    });
+
+    it('should list all branches including remote-tracking', async () => {
+      await writeFile(join(tempDir, 'file.txt'), 'content');
+      execSync('git add . && git commit -m "init"', { cwd: tempDir, stdio: 'ignore' });
+
+      const tool = buildToolDefinition(BRANCH_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({ all: true });
+      expect(result.isError).toBeUndefined();
+    });
+  });
+
+  describe('git_show tool', () => {
+    it('should show HEAD commit', async () => {
+      await writeFile(join(tempDir, 'file.txt'), 'content');
+      execSync('git add . && git commit -m "show me"', { cwd: tempDir, stdio: 'ignore' });
+
+      const tool = buildToolDefinition(SHOW_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({ ref: 'HEAD' });
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toContain('show me');
+    });
+
+    it('should show default ref (HEAD) when not specified', async () => {
+      await writeFile(join(tempDir, 'file.txt'), 'content');
+      execSync('git add . && git commit -m "default ref"', { cwd: tempDir, stdio: 'ignore' });
+
+      const tool = buildToolDefinition(SHOW_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({});
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toContain('default ref');
+    });
+  });
+
+  describe('git_blame tool', () => {
+    it('should show blame for a file', async () => {
+      await writeFile(join(tempDir, 'hello.txt'), 'blame this line');
+      execSync('git add . && git commit -m "blame test"', { cwd: tempDir, stdio: 'ignore' });
+
+      const tool = buildToolDefinition(BLAME_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({ file: 'hello.txt' });
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toContain('blame this line');
+    });
+
+    it('should return error for missing file', async () => {
+      await writeFile(join(tempDir, 'hello.txt'), 'content');
+      execSync('git add . && git commit -m "init"', { cwd: tempDir, stdio: 'ignore' });
+
+      const tool = buildToolDefinition(BLAME_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({ file: 'nonexistent.txt' });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('git_remote tool', () => {
+    it('should return empty output when no remotes configured', async () => {
+      const tool = buildToolDefinition(REMOTE_CONFIG, { cwd: tempDir });
+      const result = await tool.handler({});
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toBe('(no output)');
+    });
+  });
+
+  describe('guard validation at runtime', () => {
+    it('should reject destructive extra args', async () => {
+      const maliciousConfig: CommandConfig = {
+        name: 'git_log_bad',
+        description: 'Should fail',
+        command: 'git',
+        args: ['log'],
+        allowExtraArgs: true,
+        extraArgsSchema: {
+          type: 'object',
+          properties: {
+            ref: { type: 'string', description: 'ref' },
+          },
+        },
+      };
+
+      const tool = buildToolDefinition(maliciousConfig, { cwd: tempDir });
+      // Try to inject a shell operator via string arg
+      await expect(tool.handler({ ref: '; rm -rf /' })).rejects.toThrow(/shell operator/);
+    });
+  });
+});
+
+describe('buildTools', () => {
+  it('should build tools for all config entries', () => {
+    const tools = buildTools([STATUS_CONFIG, LOG_CONFIG, REMOTE_CONFIG]);
+    expect(tools).toHaveLength(3);
+    expect(tools.map((t) => t.name)).toEqual(['git_status', 'git_log', 'git_remote']);
+  });
+
+  it('should return empty array for empty config', () => {
+    const tools = buildTools([]);
+    expect(tools).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- validate blocked sequences against combined base + extra args at runtime
- enforce `enum` constraints when building input schemas for string/number/boolean properties
- add regression tests for combined-arg destructive sequences and enum enforcement

## Validation
- `npm test -- tests/config/guard.test.ts tests/git/tools.test.ts`

## Context
This addresses follow-up review findings around runtime safety and config-contract enforcement in git tool schema generation.