### PR TITLE
fix: enforce combined-arg guard and enum constraints

### DIFF
--- a/src/config/guard.ts
+++ b/src/config/guard.ts
@@ -125,3 +125,22 @@ export function validateExtraArgs(commandName: string, extraArgs: readonly strin
   checkDestructiveSubcommand(commandName, extraArgs);
   checkBlockedSequences(commandName, extraArgs);
 }
+
+/**
+ * Validate the combined base args + extra args together.
+ *
+ * This catches destructive sequences that span the boundary between
+ * configured base args and user-supplied extra args (e.g. base=['tag']
+ * combined with extra=['--delete', 'v1'] forms the blocked sequence
+ * "tag --delete").
+ */
+export function validateCombinedArgs(
+  commandName: string,
+  baseArgs: readonly string[],
+  extraArgs: readonly string[],
+): void {
+  // Extra args are already validated individually by validateExtraArgs;
+  // here we only need to check blocked sequences across the combined list.
+  const combined = [...baseArgs, ...extraArgs];
+  checkBlockedSequences(commandName, combined);
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,6 +6,7 @@ export { loadConfig, parseConfig, ConfigLoadError, ConfigValidationError } from 
 export {
   validateCommandArgs,
   validateExtraArgs,
+  validateCombinedArgs,
   DestructiveCommandError,
   BLOCKED_SUBCOMMANDS,
   BLOCKED_ARG_SEQUENCES,

--- a/src/git/tools.ts
+++ b/src/git/tools.ts
@@ -14,7 +14,7 @@ import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { type ToolDefinition } from '../server/registry.js';
 import { ToolExecutionError } from '../server/errors.js';
 import { Logger } from '../server/logger.js';
-import { validateExtraArgs } from '../config/guard.js';
+import { validateExtraArgs, validateCombinedArgs } from '../config/guard.js';
 import { type CommandConfig, type ExtraArgsSchema, type ExtraArgsProperty } from '../config/types.js';
 import { runGit, type RunGitOptions } from './runner.js';
 
@@ -28,13 +28,30 @@ function propertyToZod(prop: ExtraArgsProperty): z.ZodTypeAny {
 
   switch (prop.type) {
     case 'string':
-      schema = z.string().describe(prop.description ?? '');
+      if (prop.enum && prop.enum.length > 0) {
+        const values = prop.enum.map(String) as [string, ...string[]];
+        schema = z.enum(values).describe(prop.description ?? '');
+      } else {
+        schema = z.string().describe(prop.description ?? '');
+      }
       break;
     case 'number':
-      schema = z.number().describe(prop.description ?? '');
+      if (prop.enum && prop.enum.length > 0) {
+        const literals = prop.enum.map((v) => z.literal(Number(v)));
+        schema = z.union(literals as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
+          .describe(prop.description ?? '');
+      } else {
+        schema = z.number().describe(prop.description ?? '');
+      }
       break;
     case 'boolean':
-      schema = z.boolean().describe(prop.description ?? '');
+      if (prop.enum && prop.enum.length > 0) {
+        const literals = prop.enum.map((v) => z.literal(Boolean(v)));
+        schema = z.union(literals as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
+          .describe(prop.description ?? '');
+      } else {
+        schema = z.boolean().describe(prop.description ?? '');
+      }
       break;
   }
 
@@ -142,10 +159,11 @@ export function buildToolDefinition(
       if (config.allowExtraArgs && args && Object.keys(args).length > 0) {
         const extraArgs = buildExtraCliArgs(config, args);
 
-        // Validate extra args through the guard
+        // Validate extra args individually and combined with base args
         if (extraArgs.length > 0) {
           try {
             validateExtraArgs(config.name, extraArgs);
+            validateCombinedArgs(config.name, config.args, extraArgs);
           } catch (err) {
             throw new ToolExecutionError(
               config.name,

--- a/tests/config/guard.test.ts
+++ b/tests/config/guard.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   validateCommandArgs,
   validateExtraArgs,
+  validateCombinedArgs,
   DestructiveCommandError,
   BLOCKED_SUBCOMMANDS,
   BLOCKED_SHELL_OPERATORS,
@@ -124,5 +125,40 @@ describe('validateExtraArgs', () => {
     expect(() => validateExtraArgs('git_log', ['>', '/tmp/out'])).toThrow(
       DestructiveCommandError,
     );
+  });
+});
+
+describe('validateCombinedArgs', () => {
+  it('should block sequences spanning base and extra args', () => {
+    // base=['tag'], extra=['--delete', 'v1'] → combined=['tag', '--delete', 'v1']
+    expect(() => validateCombinedArgs('git_tag', ['tag'], ['--delete', 'v1'])).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should block "tag -d" spanning base and extra args', () => {
+    expect(() => validateCombinedArgs('git_tag', ['tag'], ['-d', 'v1'])).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should block "branch --delete" spanning base and extra args', () => {
+    expect(() => validateCombinedArgs('git_branch', ['branch'], ['--delete', 'feat'])).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should block "branch -D" spanning base and extra args', () => {
+    expect(() => validateCombinedArgs('git_branch', ['branch'], ['-D', 'feat'])).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should allow safe combined args', () => {
+    expect(() => validateCombinedArgs('git_tag', ['tag'], ['-l'])).not.toThrow();
+  });
+
+  it('should allow empty extra args', () => {
+    expect(() => validateCombinedArgs('git_log', ['log', '--oneline'], [])).not.toThrow();
   });
 });

--- a/tests/git/tools.test.ts
+++ b/tests/git/tools.test.ts
@@ -14,6 +14,7 @@ import { execSync } from 'node:child_process';
 
 import { buildToolDefinition, buildTools } from '../../src/git/tools.js';
 import { type CommandConfig } from '../../src/config/types.js';
+import { z } from 'zod';
 
 // Suppress logger output during tests
 vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
@@ -329,6 +330,45 @@ describe('buildToolDefinition', () => {
       // Try to inject a shell operator via string arg
       await expect(tool.handler({ ref: '; rm -rf /' })).rejects.toThrow(/shell operator/);
     });
+
+    it('should reject destructive sequences spanning base and extra args', async () => {
+      // Base args contain 'tag', user supplies '--delete' via extra arg
+      const tagConfig: CommandConfig = {
+        name: 'git_tag',
+        description: 'List tags',
+        command: 'git',
+        args: ['tag'],
+        allowExtraArgs: true,
+        extraArgsSchema: {
+          type: 'object',
+          properties: {
+            flag: { type: 'string', description: 'flag' },
+          },
+        },
+      };
+
+      const tool = buildToolDefinition(tagConfig, { cwd: tempDir });
+      await expect(tool.handler({ flag: '--delete' })).rejects.toThrow(/destructive sequence/);
+    });
+
+    it('should reject branch --delete spanning base and extra args', async () => {
+      const branchDeleteConfig: CommandConfig = {
+        name: 'git_branch_del',
+        description: 'Should fail',
+        command: 'git',
+        args: ['branch'],
+        allowExtraArgs: true,
+        extraArgsSchema: {
+          type: 'object',
+          properties: {
+            flag: { type: 'string', description: 'flag' },
+          },
+        },
+      };
+
+      const tool = buildToolDefinition(branchDeleteConfig, { cwd: tempDir });
+      await expect(tool.handler({ flag: '-D' })).rejects.toThrow(/destructive sequence/);
+    });
   });
 });
 
@@ -342,5 +382,122 @@ describe('buildTools', () => {
   it('should return empty array for empty config', () => {
     const tools = buildTools([]);
     expect(tools).toHaveLength(0);
+  });
+});
+
+describe('enum enforcement in input schemas', () => {
+  it('should restrict string properties to enum values', () => {
+    const config: CommandConfig = {
+      name: 'git_log_enum',
+      description: 'Log with enum format',
+      command: 'git',
+      args: ['log'],
+      allowExtraArgs: true,
+      extraArgsSchema: {
+        type: 'object',
+        properties: {
+          format: {
+            type: 'string',
+            description: 'Output format',
+            enum: ['oneline', 'short', 'full'],
+          },
+        },
+      },
+    };
+
+    const tool = buildToolDefinition(config);
+    const schema = z.object(tool.inputSchema);
+
+    // Valid values should pass
+    expect(() => schema.parse({ format: 'oneline' })).not.toThrow();
+    expect(() => schema.parse({ format: 'short' })).not.toThrow();
+    expect(() => schema.parse({ format: 'full' })).not.toThrow();
+
+    // Invalid value should fail
+    expect(() => schema.parse({ format: 'evil-format' })).toThrow();
+  });
+
+  it('should restrict number properties to enum values', () => {
+    const config: CommandConfig = {
+      name: 'git_log_limit',
+      description: 'Log with enum limit',
+      command: 'git',
+      args: ['log'],
+      allowExtraArgs: true,
+      extraArgsSchema: {
+        type: 'object',
+        properties: {
+          limit: {
+            type: 'number',
+            description: 'Number of commits',
+            enum: [5, 10, 25, 50],
+          },
+        },
+      },
+    };
+
+    const tool = buildToolDefinition(config);
+    const schema = z.object(tool.inputSchema);
+
+    // Valid values should pass
+    expect(() => schema.parse({ limit: 10 })).not.toThrow();
+    expect(() => schema.parse({ limit: 50 })).not.toThrow();
+
+    // Invalid value should fail
+    expect(() => schema.parse({ limit: 999 })).toThrow();
+  });
+
+  it('should allow unconstrained values when no enum is set', () => {
+    const config: CommandConfig = {
+      name: 'git_log_free',
+      description: 'Log without enum',
+      command: 'git',
+      args: ['log'],
+      allowExtraArgs: true,
+      extraArgsSchema: {
+        type: 'object',
+        properties: {
+          ref: {
+            type: 'string',
+            description: 'Any ref',
+          },
+        },
+      },
+    };
+
+    const tool = buildToolDefinition(config);
+    const schema = z.object(tool.inputSchema);
+
+    // Any string should be accepted
+    expect(() => schema.parse({ ref: 'anything-goes' })).not.toThrow();
+  });
+
+  it('should restrict boolean properties to enum values', () => {
+    const config: CommandConfig = {
+      name: 'git_diff_enum_bool',
+      description: 'Diff with enum boolean',
+      command: 'git',
+      args: ['diff'],
+      allowExtraArgs: true,
+      extraArgsSchema: {
+        type: 'object',
+        properties: {
+          staged: {
+            type: 'boolean',
+            description: 'Must be true',
+            enum: [true],
+          },
+        },
+      },
+    };
+
+    const tool = buildToolDefinition(config);
+    const schema = z.object(tool.inputSchema);
+
+    // Only true should pass
+    expect(() => schema.parse({ staged: true })).not.toThrow();
+
+    // false should fail
+    expect(() => schema.parse({ staged: false })).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- validate blocked sequences against combined base + extra args at runtime
- enforce `enum` constraints in `propertyToZod` for string, number, and boolean properties
- add regression tests for combined-arg destructive sequences and enum enforcement

## Validation
- `npm test -- tests/config/guard.test.ts tests/git/tools.test.ts`