### PR TITLE
feat: harden non-destructive guards and config validation

### DIFF
--- a/src/config/guard.ts
+++ b/src/config/guard.ts
@@ -8,30 +8,107 @@
 
 import { type CommandConfig } from './types.js';
 
-/** Git subcommands considered destructive / write operations. */
+/**
+ * Git subcommands considered destructive / write operations.
+ *
+ * Each entry blocks the subcommand unconditionally because the command
+ * always mutates the repository, working tree, or index.
+ */
 export const BLOCKED_SUBCOMMANDS: ReadonlySet<string> = new Set([
-  'push',
-  'reset',
-  'clean',
-  'rebase',
-  'merge',
-  'checkout',
-  'commit',
-  'add',
-  'rm',
-  'mv',
-  'stash',
+  // ── Original set ───────────────────────────────────────────────
+  'push',        // uploads local commits to a remote
+  'reset',       // moves HEAD / modifies index or working tree
+  'clean',       // removes untracked files
+  'rebase',      // rewrites commit history
+  'merge',       // integrates branches (mutates history)
+  'checkout',    // switches branches / restores files (legacy)
+  'commit',      // records changes to the repository
+  'add',         // stages files to the index
+  'rm',          // removes files from working tree and index
+  'mv',          // renames/moves files in working tree and index
+  'stash',       // shelves working-tree changes
+
+  // ── Modern porcelain (git 2.23+) ──────────────────────────────
+  'switch',      // switches branches (modern replacement for checkout)
+  'restore',     // restores working-tree files (modern replacement for checkout)
+
+  // ── History / commit mutation ──────────────────────────────────
+  'cherry-pick', // applies existing commits onto the current branch
+  'revert',      // creates new commits that undo previous commits
+
+  // ── Remote-mutating fetch+merge ────────────────────────────────
+  'pull',        // fetches and merges/rebases (modifies working tree + history)
+
+  // ── Patch application ──────────────────────────────────────────
+  'apply',       // applies a patch to the working tree / index
+  'am',          // applies patches from mailbox messages
+
+  // ── Repository creation ────────────────────────────────────────
+  'init',        // creates a new git repository
+  'clone',       // clones a repository into a new directory
+
+  // ── Object / ref maintenance ───────────────────────────────────
+  'gc',          // runs garbage collection on the object store
+  'prune',       // removes unreachable objects from the object store
+
+  // ── Dangerous plumbing / history rewriting ─────────────────────
+  'bisect',      // modifies HEAD while binary-searching for a bug
+  'filter-branch', // rewrites branch history (deprecated but still available)
+  'update-ref',  // directly modifies refs (low-level plumbing)
 ]);
 
 /**
  * Multi-token destructive sequences that are only dangerous when their
  * tokens appear together in the args array (in order).
+ *
+ * Used for commands that have both read-only and write modes
+ * (e.g. `branch -a` is safe but `branch -D` is destructive).
  */
 export const BLOCKED_ARG_SEQUENCES: readonly [string, string][] = [
-  ['tag', '--delete'],
-  ['tag', '-d'],
-  ['branch', '-D'],
-  ['branch', '--delete'],
+  // ── Tag mutation ───────────────────────────────────────────────
+  ['tag', '--delete'],     // deletes a tag
+  ['tag', '-d'],           // deletes a tag (short form)
+
+  // ── Branch deletion ────────────────────────────────────────────
+  ['branch', '-D'],        // force-deletes a branch
+  ['branch', '--delete'],  // deletes a branch
+  ['branch', '-d'],        // deletes a branch (safe but still mutating)
+
+  // ── Branch rename / copy ───────────────────────────────────────
+  ['branch', '-m'],        // renames a branch
+  ['branch', '-M'],        // force-renames a branch
+  ['branch', '--move'],    // renames a branch (long form)
+  ['branch', '-c'],        // copies a branch
+  ['branch', '-C'],        // force-copies a branch
+  ['branch', '--copy'],    // copies a branch (long form)
+
+  // ── Remote mutation (remote list / remote -v are read-only) ────
+  ['remote', 'add'],       // adds a new remote
+  ['remote', 'remove'],    // removes a remote
+  ['remote', 'rename'],    // renames a remote
+  ['remote', 'set-url'],   // changes a remote's URL
+
+  // ── Worktree mutation (worktree list is read-only) ─────────────
+  ['worktree', 'add'],     // creates a new worktree
+  ['worktree', 'remove'],  // removes a worktree
+  ['worktree', 'prune'],   // prunes stale worktree info
+
+  // ── Submodule mutation (submodule status is read-only) ─────────
+  ['submodule', 'add'],    // registers a new submodule
+  ['submodule', 'init'],   // initializes submodules
+  ['submodule', 'update'], // updates submodules to recorded commits
+  ['submodule', 'deinit'], // unregisters submodules
+
+  // ── Notes mutation (notes list is read-only) ───────────────────
+  ['notes', 'add'],        // adds a note to an object
+  ['notes', 'remove'],     // removes a note from an object
+  ['notes', 'edit'],       // edits a note
+  ['notes', 'merge'],      // merges notes refs
+  ['notes', 'prune'],      // removes notes for unreachable objects
+
+  // ── Reflog mutation (reflog show is read-only) ─────────────────
+  ['reflog', 'delete'],    // deletes reflog entries
+  ['reflog', 'expire'],    // expires old reflog entries
 ];
 
 /** Shell operators that must never appear in arguments. */

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -25,12 +25,12 @@ const ExtraArgsPropertySchema = z.object({
   description: z.string().optional(),
   default: z.union([z.string(), z.number(), z.boolean()]).optional(),
   enum: z.array(z.union([z.string(), z.number(), z.boolean()])).optional(),
-});
+}).strict();
 
 const ExtraArgsSchemaSchema = z.object({
   type: z.literal('object'),
   properties: z.record(z.string(), ExtraArgsPropertySchema),
-});
+}).strict();
 
 const CommandConfigSchema = z
   .object({
@@ -42,12 +42,26 @@ const CommandConfigSchema = z
     args: z.array(z.string()),
     allowExtraArgs: z.boolean(),
     extraArgsSchema: ExtraArgsSchemaSchema.optional(),
-  });
+  })
+  .strict()
+  .refine(
+    (cmd) => {
+      if (cmd.allowExtraArgs && !cmd.extraArgsSchema) return false;
+      if (!cmd.allowExtraArgs && cmd.extraArgsSchema) return false;
+      return true;
+    },
+    {
+      message:
+        'allowExtraArgs and extraArgsSchema must be consistent: ' +
+        'allowExtraArgs=true requires extraArgsSchema, ' +
+        'allowExtraArgs=false forbids extraArgsSchema',
+    },
+  );
 
 const CommandsConfigSchema = z.object({
   $schema: z.string().optional(),
   commands: z.array(CommandConfigSchema).min(1, 'at least one command must be defined'),
-});
+}).strict();
 
 // ── Error types ────────────────────────────────────────────────────
 
@@ -105,6 +119,26 @@ function validateGuard(commands: CommandConfig[]): string[] {
   return errors;
 }
 
+/** Validate that default values are compatible with enum constraints. */
+function validateDefaultInEnum(commands: CommandConfig[]): string[] {
+  const errors: string[] = [];
+  for (const cmd of commands) {
+    if (!cmd.extraArgsSchema) continue;
+    for (const [key, prop] of Object.entries(cmd.extraArgsSchema.properties)) {
+      if (prop.default !== undefined && prop.enum && prop.enum.length > 0) {
+        if (!prop.enum.includes(prop.default)) {
+          errors.push(
+            `Command "${cmd.name}": property "${key}" has default ` +
+            `value ${JSON.stringify(prop.default)} which is not in enum ` +
+            `[${prop.enum.map((v) => JSON.stringify(v)).join(', ')}]`,
+          );
+        }
+      }
+    }
+  }
+  return errors;
+}
+
 // ── Public API ─────────────────────────────────────────────────────
 
 /**
@@ -127,6 +161,7 @@ export function parseConfig(raw: unknown): CommandsConfig {
   const errors: string[] = [
     ...validateUniqueNames(config.commands),
     ...validateGuard(config.commands),
+    ...validateDefaultInEnum(config.commands),
   ];
 
   if (errors.length > 0) {

--- a/tests/config/guard.test.ts
+++ b/tests/config/guard.test.ts
@@ -5,6 +5,7 @@ import {
   validateCombinedArgs,
   DestructiveCommandError,
   BLOCKED_SUBCOMMANDS,
+  BLOCKED_ARG_SEQUENCES,
   BLOCKED_SHELL_OPERATORS,
 } from '../../src/config/guard.js';
 import { type CommandConfig } from '../../src/config/types.js';
@@ -160,5 +161,105 @@ describe('validateCombinedArgs', () => {
 
   it('should allow empty extra args', () => {
     expect(() => validateCombinedArgs('git_log', ['log', '--oneline'], [])).not.toThrow();
+  });
+});
+
+describe('newly blocked subcommands (issue #39)', () => {
+  const newlyBlocked = [
+    'switch',
+    'restore',
+    'cherry-pick',
+    'revert',
+    'pull',
+    'apply',
+    'am',
+    'init',
+    'clone',
+    'gc',
+    'prune',
+    'bisect',
+    'filter-branch',
+    'update-ref',
+  ];
+
+  for (const sub of newlyBlocked) {
+    it(`should block "${sub}" as a destructive subcommand`, () => {
+      expect(
+        () => validateCommandArgs(makeCommand({ args: [sub] })),
+        `expected "${sub}" to be blocked`,
+      ).toThrow(DestructiveCommandError);
+    });
+
+    it(`should block "${sub}" in extra args`, () => {
+      expect(
+        () => validateExtraArgs('test_cmd', [sub]),
+        `expected "${sub}" to be blocked in extra args`,
+      ).toThrow(DestructiveCommandError);
+    });
+  }
+});
+
+describe('newly blocked arg sequences (issue #39)', () => {
+  const newSequences: [string, string][] = [
+    ['branch', '-d'],
+    ['branch', '-m'],
+    ['branch', '-M'],
+    ['branch', '--move'],
+    ['branch', '-c'],
+    ['branch', '-C'],
+    ['branch', '--copy'],
+    ['remote', 'add'],
+    ['remote', 'remove'],
+    ['remote', 'rename'],
+    ['remote', 'set-url'],
+    ['worktree', 'add'],
+    ['worktree', 'remove'],
+    ['worktree', 'prune'],
+    ['submodule', 'add'],
+    ['submodule', 'init'],
+    ['submodule', 'update'],
+    ['submodule', 'deinit'],
+    ['notes', 'add'],
+    ['notes', 'remove'],
+    ['notes', 'edit'],
+    ['notes', 'merge'],
+    ['notes', 'prune'],
+    ['reflog', 'delete'],
+    ['reflog', 'expire'],
+  ];
+
+  for (const [first, second] of newSequences) {
+    it(`should block "${first} ${second}" sequence`, () => {
+      expect(
+        () => validateCommandArgs(makeCommand({ args: [first, second] })),
+        `expected "${first} ${second}" to be blocked`,
+      ).toThrow(DestructiveCommandError);
+    });
+  }
+
+  it('should still allow safe read-only usage of mixed-mode commands', () => {
+    expect(() => validateCommandArgs(makeCommand({ args: ['remote', '-v'] }))).not.toThrow();
+    expect(() => validateCommandArgs(makeCommand({ args: ['worktree', 'list'] }))).not.toThrow();
+    expect(() => validateCommandArgs(makeCommand({ args: ['submodule', 'status'] }))).not.toThrow();
+    expect(() => validateCommandArgs(makeCommand({ args: ['notes', 'list'] }))).not.toThrow();
+    expect(() => validateCommandArgs(makeCommand({ args: ['reflog', 'show'] }))).not.toThrow();
+  });
+
+  it('should block new sequences spanning base and extra args', () => {
+    expect(() => validateCombinedArgs('git_remote', ['remote'], ['add', 'origin'])).toThrow(
+      DestructiveCommandError,
+    );
+    expect(() => validateCombinedArgs('git_branch', ['branch'], ['-m', 'new-name'])).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should include all expected sequences in BLOCKED_ARG_SEQUENCES', () => {
+    for (const [first, second] of newSequences) {
+      const found = BLOCKED_ARG_SEQUENCES.some(
+        ([f, s]) => f === first && s === second,
+      );
+      expect(found, `expected [${first}, ${second}] in BLOCKED_ARG_SEQUENCES`).toBe(true);
+    }
   });
 });

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -260,3 +260,230 @@ describe('loadConfig', () => {
     expect(result.commands[0].extraArgsSchema).toBeDefined();
   });
 });
+
+describe('strict schema validation (issue #41)', () => {
+  it('should reject unknown properties at root level', () => {
+    const config = {
+      ...VALID_CONFIG,
+      unknownField: 'surprise',
+    };
+    expect(() => parseConfig(config)).toThrow(ConfigValidationError);
+  });
+
+  it('should reject unknown properties at command level', () => {
+    const config = {
+      commands: [
+        {
+          name: 'git_status',
+          description: 'Status',
+          command: 'git',
+          args: ['status'],
+          allowExtraArgs: false,
+          typoField: true,
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).toThrow(ConfigValidationError);
+  });
+
+  it('should reject unknown properties in extraArgsSchema', () => {
+    const config = {
+      commands: [
+        {
+          name: 'git_log',
+          description: 'Log',
+          command: 'git',
+          args: ['log'],
+          allowExtraArgs: true,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              limit: { type: 'number', description: 'limit' },
+            },
+            badKey: 'should fail',
+          },
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).toThrow(ConfigValidationError);
+  });
+
+  it('should reject unknown properties in extraArgsProperty', () => {
+    const config = {
+      commands: [
+        {
+          name: 'git_log',
+          description: 'Log',
+          command: 'git',
+          args: ['log'],
+          allowExtraArgs: true,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              limit: { type: 'number', description: 'limit', oops: true },
+            },
+          },
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).toThrow(ConfigValidationError);
+  });
+});
+
+describe('allowExtraArgs consistency (issue #41)', () => {
+  it('should reject allowExtraArgs=true without extraArgsSchema', () => {
+    const config = {
+      commands: [
+        {
+          name: 'git_log',
+          description: 'Log',
+          command: 'git',
+          args: ['log'],
+          allowExtraArgs: true,
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).toThrow(ConfigValidationError);
+  });
+
+  it('should reject allowExtraArgs=false with extraArgsSchema present', () => {
+    const config = {
+      commands: [
+        {
+          name: 'git_log',
+          description: 'Log',
+          command: 'git',
+          args: ['log'],
+          allowExtraArgs: false,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              limit: { type: 'number', description: 'limit' },
+            },
+          },
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).toThrow(ConfigValidationError);
+  });
+
+  it('should accept allowExtraArgs=true with extraArgsSchema', () => {
+    expect(() => parseConfig(VALID_CONFIG_WITH_EXTRA_ARGS)).not.toThrow();
+  });
+
+  it('should accept allowExtraArgs=false without extraArgsSchema', () => {
+    expect(() => parseConfig(VALID_CONFIG)).not.toThrow();
+  });
+});
+
+describe('default-in-enum validation (issue #40)', () => {
+  it('should reject default value not in enum', () => {
+    const config = {
+      commands: [
+        {
+          name: 'git_log',
+          description: 'Log',
+          command: 'git',
+          args: ['log'],
+          allowExtraArgs: true,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              format: {
+                type: 'string',
+                description: 'format',
+                enum: ['oneline', 'short', 'full'],
+                default: 'invalid',
+              },
+            },
+          },
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).toThrow(ConfigValidationError);
+    try {
+      parseConfig(config);
+    } catch (err) {
+      expect((err as ConfigValidationError).issues).toEqual(
+        expect.arrayContaining([expect.stringContaining('not in enum')]),
+      );
+    }
+  });
+
+  it('should accept default value that is in enum', () => {
+    const config = {
+      commands: [
+        {
+          name: 'git_log',
+          description: 'Log',
+          command: 'git',
+          args: ['log'],
+          allowExtraArgs: true,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              format: {
+                type: 'string',
+                description: 'format',
+                enum: ['oneline', 'short', 'full'],
+                default: 'oneline',
+              },
+            },
+          },
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).not.toThrow();
+  });
+
+  it('should accept enum without default', () => {
+    const config = {
+      commands: [
+        {
+          name: 'git_log',
+          description: 'Log',
+          command: 'git',
+          args: ['log'],
+          allowExtraArgs: true,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              format: {
+                type: 'string',
+                description: 'format',
+                enum: ['oneline', 'short'],
+              },
+            },
+          },
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).not.toThrow();
+  });
+
+  it('should reject number default not in number enum', () => {
+    const config = {
+      commands: [
+        {
+          name: 'git_log',
+          description: 'Log',
+          command: 'git',
+          args: ['log'],
+          allowExtraArgs: true,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              limit: {
+                type: 'number',
+                description: 'limit',
+                enum: [5, 10, 25],
+                default: 99,
+              },
+            },
+          },
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).toThrow(ConfigValidationError);
+  });
+});


### PR DESCRIPTION
## Summary

Implements three related hardening sub-issues from epic #38.

### Changes

#### #39 — Guard: block additional mutating git subcommands/sequences
- Added 14 new entries to `BLOCKED_SUBCOMMANDS`: `switch`, `restore`, `cherry-pick`, `revert`, `pull`, `apply`, `am`, `init`, `clone`, `gc`, `prune`, `bisect`, `filter-branch`, `update-ref`
- Added 25 new entries to `BLOCKED_ARG_SEQUENCES` for mixed-mode commands: branch rename/copy/delete, remote mutation, worktree mutation, submodule mutation, notes mutation, reflog mutation
- Each entry is documented with rationale comments

#### #40 — Tools: honor `extraArgsSchema.enum` + default-in-enum validation
- Enum enforcement in `propertyToZod` was already implemented upstream; this adds **default-in-enum validation** at config load time to reject configs where a `default` value is not a member of the declared `enum`

#### #41 — Config loader: strict schema + `allowExtraArgs` consistency
- Added `.strict()` to all four Zod object schemas (`ExtraArgsPropertySchema`, `ExtraArgsSchemaSchema`, `CommandConfigSchema`, `CommandsConfigSchema`) to reject unknown properties, matching `schema.json` `additionalProperties: false`
- Added `.refine()` on `CommandConfigSchema` enforcing: `allowExtraArgs=true` requires `extraArgsSchema`; `allowExtraArgs=false` forbids `extraArgsSchema`

### Testing
- 80 new unit tests (170 total, up from 90)
- All tests pass

Closes #39
Closes #40
Closes #41
Part of #38