### PR TITLE
feat: add git commands for code review workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ GITPRIDE_CONFIG=./my-config.json gitpride
 
 The included [`commands.config.json`](./commands.config.json) exposes these tools:
 
-| Tool          | Git Command     | Extra Args                |
-| ------------- | --------------- | ------------------------- |
-| `git_status`  | `git status`    | —                         |
-| `git_log`     | `git log`       | `limit` (number)          |
-| `git_diff`    | `git diff`      | `ref` (string), `staged` (boolean) |
-| `git_branch`  | `git branch`    | `all` (boolean)           |
-| `git_show`    | `git show`      | `ref` (string)            |
-| `git_blame`   | `git blame`     | `file` (string)           |
-| `git_remote`  | `git remote -v` | —                         |
+| Tool         | Git Command     | Extra Args                         |
+| ------------ | --------------- | ---------------------------------- |
+| `git_status` | `git status`    | —                                  |
+| `git_log`    | `git log`       | `limit` (number)                   |
+| `git_diff`   | `git diff`      | `ref` (string), `staged` (boolean) |
+| `git_branch` | `git branch`    | `all` (boolean)                    |
+| `git_show`   | `git show`      | `ref` (string)                     |
+| `git_blame`  | `git blame`     | `file` (string)                    |
+| `git_remote` | `git remote -v` | —                                  |
 
 ## Configuration
 
@@ -117,12 +117,12 @@ For the complete field reference, property type mapping, and security rules, see
 
 Ready-to-use configurations are in the [`examples/`](./examples/) directory:
 
-| File | Use Case |
-| ---- | -------- |
-| [`minimal.config.json`](./examples/minimal.config.json) | Bare minimum — status and log only |
-| [`full.config.json`](./examples/full.config.json) | All 7 default commands |
-| [`code-review.config.json`](./examples/code-review.config.json) | Diff, blame, and log for reviews |
-| [`history.config.json`](./examples/history.config.json) | Repository history exploration |
+| File                                                            | Use Case                           |
+| --------------------------------------------------------------- | ---------------------------------- |
+| [`minimal.config.json`](./examples/minimal.config.json)         | Bare minimum — status and log only |
+| [`full.config.json`](./examples/full.config.json)               | All 7 default commands             |
+| [`code-review.config.json`](./examples/code-review.config.json) | Diff, blame, and log for reviews   |
+| [`history.config.json`](./examples/history.config.json)         | Repository history exploration     |
 
 ## Client Integration
 
@@ -183,10 +183,10 @@ Add to `.vscode/mcp.json` in your workspace:
 
 ## Environment Variables
 
-| Variable          | Description                              | Default                        |
-| ----------------- | ---------------------------------------- | ------------------------------ |
-| `GITPRIDE_CONFIG` | Path to the command configuration file   | `./commands.config.json`       |
-| `LOG_LEVEL`       | Log verbosity: `debug`, `info`, `warn`, `error` | `info`                 |
+| Variable          | Description                                     | Default                  |
+| ----------------- | ----------------------------------------------- | ------------------------ |
+| `GITPRIDE_CONFIG` | Path to the command configuration file          | `./commands.config.json` |
+| `LOG_LEVEL`       | Log verbosity: `debug`, `info`, `warn`, `error` | `info`                   |
 
 ## Security
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,14 +16,18 @@ If no config file is found and `GITPRIDE_CONFIG` is not set, the server starts w
 ```json
 {
   "$schema": "./src/config/schema.json",
+  "allowedOperations": ["merge", "rebase", "checkout", "switch", "branch:delete"],
+  "protectedBranches": ["main", "master", "develop"],
   "commands": [...]
 }
 ```
 
-| Field      | Type   | Required | Description                                              |
-| ---------- | ------ | -------- | -------------------------------------------------------- |
-| `$schema`  | string | No       | Path or URL to the JSON Schema (enables editor autocompletion) |
-| `commands` | array  | Yes      | List of command definitions (minimum 1)                  |
+| Field               | Type     | Required | Description                                                                    |
+| ------------------- | -------- | -------- | ------------------------------------------------------------------------------ |
+| `$schema`           | string   | No       | Path or URL to the JSON Schema (enables editor autocompletion)                 |
+| `commands`          | array    | Yes      | List of command definitions (minimum 1)                                        |
+| `allowedOperations` | string[] | No       | Operations normally blocked by the guard that this config explicitly permits   |
+| `protectedBranches` | string[] | No       | Branch names that must never be deleted (requires `branch:delete` to be useful)|
 
 ## Command Definition
 
@@ -145,6 +149,41 @@ The following are **blocked**:
 
 Any config file or runtime invocation containing these will be rejected with a `DestructiveCommandError`.
 
+### Allowed Operations
+
+By default, all destructive git operations are blocked. The `allowedOperations` field lets you opt in to specific write operations for workflows like code review:
+
+| Value            | Unblocks                                     |
+| ---------------- | -------------------------------------------- |
+| `"merge"`        | `git merge`                                  |
+| `"rebase"`       | `git rebase`                                 |
+| `"checkout"`     | `git checkout`                               |
+| `"switch"`       | `git switch`                                 |
+| `"branch:delete"`| `branch -d`, `branch -D`, `branch --delete` |
+
+Other destructive operations (e.g. `push`, `commit`, `reset`) **cannot** be unblocked.
+
+```json
+{
+  "allowedOperations": ["merge", "rebase", "checkout", "branch:delete"],
+  "commands": [...]
+}
+```
+
+### Protected Branches
+
+When `branch:delete` is allowed, you can protect critical branches from accidental deletion:
+
+```json
+{
+  "allowedOperations": ["branch:delete"],
+  "protectedBranches": ["main", "master", "develop", "release"],
+  "commands": [...]
+}
+```
+
+Any attempt to delete a protected branch (via `branch -d`, `-D`, or `--delete`) will be rejected at runtime with a `DestructiveCommandError`, even when `branch:delete` is in `allowedOperations`.
+
 ### Execution Limits
 
 - **Timeout:** 30 seconds per command
@@ -205,6 +244,7 @@ See the [`examples/`](../examples/) directory for ready-to-use configurations:
 | [`minimal.config.json`](../examples/minimal.config.json)       | Bare minimum — status and log only         |
 | [`full.config.json`](../examples/full.config.json)             | All 7 default commands                     |
 | [`code-review.config.json`](../examples/code-review.config.json) | Focused on diff, blame, and log for reviews |
+| [`code-review-workflow.config.json`](../examples/code-review-workflow.config.json) | Full code review with merge, rebase, and branch delete |
 | [`history.config.json`](../examples/history.config.json)       | Repository history exploration             |
 
 To use an example, copy it to your project root:

--- a/examples/code-review-workflow.config.json
+++ b/examples/code-review-workflow.config.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "../src/config/schema.json",
+  "allowedOperations": ["merge", "rebase", "checkout", "switch", "branch:delete"],
+  "protectedBranches": ["main", "master", "develop", "release"],
+  "commands": [
+    {
+      "name": "git_status",
+      "description": "Show the working tree status",
+      "command": "git",
+      "args": ["status"],
+      "allowExtraArgs": false
+    },
+    {
+      "name": "git_diff",
+      "description": "Show changes between commits, commit and working tree, etc.",
+      "command": "git",
+      "args": ["diff"],
+      "allowExtraArgs": true,
+      "extraArgsSchema": {
+        "type": "object",
+        "properties": {
+          "ref": {
+            "type": "string",
+            "description": "Git ref to diff against (e.g. HEAD~1, main)"
+          },
+          "staged": {
+            "type": "boolean",
+            "description": "Show staged changes (--cached)",
+            "default": false
+          }
+        }
+      }
+    },
+    {
+      "name": "git_log",
+      "description": "Show recent commit logs for review",
+      "command": "git",
+      "args": ["log", "--oneline"],
+      "allowExtraArgs": true,
+      "extraArgsSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of commits to show",
+            "default": 20
+          }
+        }
+      }
+    },
+    {
+      "name": "git_show",
+      "description": "Show a commit's full diff and message",
+      "command": "git",
+      "args": ["show"],
+      "allowExtraArgs": true,
+      "extraArgsSchema": {
+        "type": "object",
+        "properties": {
+          "ref": {
+            "type": "string",
+            "description": "Commit SHA or ref to inspect",
+            "default": "HEAD"
+          }
+        }
+      }
+    },
+    {
+      "name": "git_blame",
+      "description": "Show what revision and author last modified each line of a file",
+      "command": "git",
+      "args": ["blame"],
+      "allowExtraArgs": true,
+      "extraArgsSchema": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "File path to blame"
+          }
+        }
+      }
+    },
+    {
+      "name": "git_branch",
+      "description": "List branches",
+      "command": "git",
+      "args": ["branch"],
+      "allowExtraArgs": true,
+      "extraArgsSchema": {
+        "type": "object",
+        "properties": {
+          "all": {
+            "type": "boolean",
+            "description": "Include remote-tracking branches",
+            "default": false
+          }
+        }
+      }
+    },
+    {
+      "name": "git_checkout",
+      "description": "Switch to a branch",
+      "command": "git",
+      "args": ["checkout"],
+      "allowExtraArgs": true,
+      "extraArgsSchema": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "type": "string",
+            "description": "Branch name to switch to"
+          }
+        }
+      }
+    },
+    {
+      "name": "git_merge",
+      "description": "Merge a branch into the current branch",
+      "command": "git",
+      "args": ["merge", "--no-edit"],
+      "allowExtraArgs": true,
+      "extraArgsSchema": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "type": "string",
+            "description": "Branch to merge into the current branch"
+          }
+        }
+      }
+    },
+    {
+      "name": "git_rebase",
+      "description": "Rebase the current branch onto another branch",
+      "command": "git",
+      "args": ["rebase"],
+      "allowExtraArgs": true,
+      "extraArgsSchema": {
+        "type": "object",
+        "properties": {
+          "onto": {
+            "type": "string",
+            "description": "Branch to rebase onto (e.g. main)"
+          }
+        }
+      }
+    },
+    {
+      "name": "git_branch_delete",
+      "description": "Delete a fully-merged feature branch (protected branches cannot be deleted)",
+      "command": "git",
+      "args": ["branch", "-d"],
+      "allowExtraArgs": true,
+      "extraArgsSchema": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "type": "string",
+            "description": "Branch name to delete"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/config/guard.ts
+++ b/src/config/guard.ts
@@ -4,9 +4,13 @@
  * The guard validates both static configuration (at load time) and
  * dynamic extra arguments (at runtime) to ensure only read-only git
  * operations are ever executed.
+ *
+ * When a config provides `allowedOperations`, the corresponding subcommands
+ * or arg sequences are exempted from blocking.  Protected branches are
+ * still enforced even when `branch:delete` is allowed.
  */
 
-import { type CommandConfig } from './types.js';
+import { type CommandConfig, type GuardOptions } from './types.js';
 
 /**
  * Git subcommands considered destructive / write operations.
@@ -16,45 +20,45 @@ import { type CommandConfig } from './types.js';
  */
 export const BLOCKED_SUBCOMMANDS: ReadonlySet<string> = new Set([
   // ── Original set ───────────────────────────────────────────────
-  'push',        // uploads local commits to a remote
-  'reset',       // moves HEAD / modifies index or working tree
-  'clean',       // removes untracked files
-  'rebase',      // rewrites commit history
-  'merge',       // integrates branches (mutates history)
-  'checkout',    // switches branches / restores files (legacy)
-  'commit',      // records changes to the repository
-  'add',         // stages files to the index
-  'rm',          // removes files from working tree and index
-  'mv',          // renames/moves files in working tree and index
-  'stash',       // shelves working-tree changes
+  'push', // uploads local commits to a remote
+  'reset', // moves HEAD / modifies index or working tree
+  'clean', // removes untracked files
+  'rebase', // rewrites commit history
+  'merge', // integrates branches (mutates history)
+  'checkout', // switches branches / restores files (legacy)
+  'commit', // records changes to the repository
+  'add', // stages files to the index
+  'rm', // removes files from working tree and index
+  'mv', // renames/moves files in working tree and index
+  'stash', // shelves working-tree changes
 
   // ── Modern porcelain (git 2.23+) ──────────────────────────────
-  'switch',      // switches branches (modern replacement for checkout)
-  'restore',     // restores working-tree files (modern replacement for checkout)
+  'switch', // switches branches (modern replacement for checkout)
+  'restore', // restores working-tree files (modern replacement for checkout)
 
   // ── History / commit mutation ──────────────────────────────────
   'cherry-pick', // applies existing commits onto the current branch
-  'revert',      // creates new commits that undo previous commits
+  'revert', // creates new commits that undo previous commits
 
   // ── Remote-mutating fetch+merge ────────────────────────────────
-  'pull',        // fetches and merges/rebases (modifies working tree + history)
+  'pull', // fetches and merges/rebases (modifies working tree + history)
 
   // ── Patch application ──────────────────────────────────────────
-  'apply',       // applies a patch to the working tree / index
-  'am',          // applies patches from mailbox messages
+  'apply', // applies a patch to the working tree / index
+  'am', // applies patches from mailbox messages
 
   // ── Repository creation ────────────────────────────────────────
-  'init',        // creates a new git repository
-  'clone',       // clones a repository into a new directory
+  'init', // creates a new git repository
+  'clone', // clones a repository into a new directory
 
   // ── Object / ref maintenance ───────────────────────────────────
-  'gc',          // runs garbage collection on the object store
-  'prune',       // removes unreachable objects from the object store
+  'gc', // runs garbage collection on the object store
+  'prune', // removes unreachable objects from the object store
 
   // ── Dangerous plumbing / history rewriting ─────────────────────
-  'bisect',      // modifies HEAD while binary-searching for a bug
+  'bisect', // modifies HEAD while binary-searching for a bug
   'filter-branch', // rewrites branch history (deprecated but still available)
-  'update-ref',  // directly modifies refs (low-level plumbing)
+  'update-ref', // directly modifies refs (low-level plumbing)
 ]);
 
 /**
@@ -66,49 +70,49 @@ export const BLOCKED_SUBCOMMANDS: ReadonlySet<string> = new Set([
  */
 export const BLOCKED_ARG_SEQUENCES: readonly [string, string][] = [
   // ── Tag mutation ───────────────────────────────────────────────
-  ['tag', '--delete'],     // deletes a tag
-  ['tag', '-d'],           // deletes a tag (short form)
+  ['tag', '--delete'], // deletes a tag
+  ['tag', '-d'], // deletes a tag (short form)
 
   // ── Branch deletion ────────────────────────────────────────────
-  ['branch', '-D'],        // force-deletes a branch
-  ['branch', '--delete'],  // deletes a branch
-  ['branch', '-d'],        // deletes a branch (safe but still mutating)
+  ['branch', '-D'], // force-deletes a branch
+  ['branch', '--delete'], // deletes a branch
+  ['branch', '-d'], // deletes a branch (safe but still mutating)
 
   // ── Branch rename / copy ───────────────────────────────────────
-  ['branch', '-m'],        // renames a branch
-  ['branch', '-M'],        // force-renames a branch
-  ['branch', '--move'],    // renames a branch (long form)
-  ['branch', '-c'],        // copies a branch
-  ['branch', '-C'],        // force-copies a branch
-  ['branch', '--copy'],    // copies a branch (long form)
+  ['branch', '-m'], // renames a branch
+  ['branch', '-M'], // force-renames a branch
+  ['branch', '--move'], // renames a branch (long form)
+  ['branch', '-c'], // copies a branch
+  ['branch', '-C'], // force-copies a branch
+  ['branch', '--copy'], // copies a branch (long form)
 
   // ── Remote mutation (remote list / remote -v are read-only) ────
-  ['remote', 'add'],       // adds a new remote
-  ['remote', 'remove'],    // removes a remote
-  ['remote', 'rename'],    // renames a remote
-  ['remote', 'set-url'],   // changes a remote's URL
+  ['remote', 'add'], // adds a new remote
+  ['remote', 'remove'], // removes a remote
+  ['remote', 'rename'], // renames a remote
+  ['remote', 'set-url'], // changes a remote's URL
 
   // ── Worktree mutation (worktree list is read-only) ─────────────
-  ['worktree', 'add'],     // creates a new worktree
-  ['worktree', 'remove'],  // removes a worktree
-  ['worktree', 'prune'],   // prunes stale worktree info
+  ['worktree', 'add'], // creates a new worktree
+  ['worktree', 'remove'], // removes a worktree
+  ['worktree', 'prune'], // prunes stale worktree info
 
   // ── Submodule mutation (submodule status is read-only) ─────────
-  ['submodule', 'add'],    // registers a new submodule
-  ['submodule', 'init'],   // initializes submodules
+  ['submodule', 'add'], // registers a new submodule
+  ['submodule', 'init'], // initializes submodules
   ['submodule', 'update'], // updates submodules to recorded commits
   ['submodule', 'deinit'], // unregisters submodules
 
   // ── Notes mutation (notes list is read-only) ───────────────────
-  ['notes', 'add'],        // adds a note to an object
-  ['notes', 'remove'],     // removes a note from an object
-  ['notes', 'edit'],       // edits a note
-  ['notes', 'merge'],      // merges notes refs
-  ['notes', 'prune'],      // removes notes for unreachable objects
+  ['notes', 'add'], // adds a note to an object
+  ['notes', 'remove'], // removes a note from an object
+  ['notes', 'edit'], // edits a note
+  ['notes', 'merge'], // merges notes refs
+  ['notes', 'prune'], // removes notes for unreachable objects
 
   // ── Reflog mutation (reflog show is read-only) ─────────────────
-  ['reflog', 'delete'],    // deletes reflog entries
-  ['reflog', 'expire'],    // expires old reflog entries
+  ['reflog', 'delete'], // deletes reflog entries
+  ['reflog', 'expire'], // expires old reflog entries
 ];
 
 /** Shell operators that must never appear in arguments. */
@@ -156,11 +160,18 @@ function checkShellOperators(commandName: string, args: readonly string[]): void
 /**
  * Validate that an argument list does not invoke a destructive git subcommand.
  * The first non-flag argument after "git" is the subcommand.
+ *
+ * When `opts.allowedSubcommands` is provided, listed subcommands are exempt.
  */
-function checkDestructiveSubcommand(commandName: string, args: readonly string[]): void {
+function checkDestructiveSubcommand(
+  commandName: string,
+  args: readonly string[],
+  opts?: GuardOptions,
+): void {
   // The first arg that doesn't start with '-' is the subcommand
   const subcommand = args.find((a) => !a.startsWith('-'));
   if (subcommand && BLOCKED_SUBCOMMANDS.has(subcommand)) {
+    if (opts?.allowedSubcommands?.has(subcommand)) return;
     throw new DestructiveCommandError(
       commandName,
       `destructive subcommand "${subcommand}" is not allowed`,
@@ -170,11 +181,21 @@ function checkDestructiveSubcommand(commandName: string, args: readonly string[]
 
 /**
  * Check for multi-token destructive sequences like "tag --delete".
+ *
+ * When `opts.allowedSequences` is provided, matching sequences are exempt.
  */
-function checkBlockedSequences(commandName: string, args: readonly string[]): void {
+function checkBlockedSequences(
+  commandName: string,
+  args: readonly string[],
+  opts?: GuardOptions,
+): void {
   for (const [first, second] of BLOCKED_ARG_SEQUENCES) {
     const firstIdx = args.indexOf(first);
     if (firstIdx !== -1 && args.indexOf(second, firstIdx + 1) !== -1) {
+      // Check if this sequence is explicitly allowed
+      if (opts?.allowedSequences?.some(([af, as]) => af === first && as === second)) {
+        continue;
+      }
       throw new DestructiveCommandError(
         commandName,
         `destructive sequence "${first} ${second}" is not allowed`,
@@ -184,23 +205,59 @@ function checkBlockedSequences(commandName: string, args: readonly string[]): vo
 }
 
 /**
+ * Check that no protected branch is the target of a branch-delete operation.
+ *
+ * Detects args like `branch -d main` or `branch --delete main` and rejects
+ * when the branch name appears in `opts.protectedBranches`.
+ */
+function checkProtectedBranches(
+  commandName: string,
+  args: readonly string[],
+  opts?: GuardOptions,
+): void {
+  if (!opts?.protectedBranches || opts.protectedBranches.length === 0) return;
+
+  const branchIdx = args.indexOf('branch');
+  if (branchIdx === -1) return;
+
+  const deleteFlags = new Set(['-d', '-D', '--delete']);
+  const hasDelete = args.some((a, i) => i > branchIdx && deleteFlags.has(a));
+  if (!hasDelete) return;
+
+  // Every non-flag arg after 'branch' that isn't the delete flag itself
+  // is a potential branch name target.
+  for (let i = branchIdx + 1; i < args.length; i++) {
+    const arg = args[i];
+    if (deleteFlags.has(arg)) continue;
+    if (arg.startsWith('-')) continue;
+    if (opts.protectedBranches.includes(arg)) {
+      throw new DestructiveCommandError(commandName, `cannot delete protected branch "${arg}"`);
+    }
+  }
+}
+
+/**
  * Validate a command's base args at config load time.
  * Throws DestructiveCommandError if the command is destructive.
  */
-export function validateCommandArgs(command: CommandConfig): void {
+export function validateCommandArgs(command: CommandConfig, opts?: GuardOptions): void {
   checkShellOperators(command.name, command.args);
-  checkDestructiveSubcommand(command.name, command.args);
-  checkBlockedSequences(command.name, command.args);
+  checkDestructiveSubcommand(command.name, command.args, opts);
+  checkBlockedSequences(command.name, command.args, opts);
 }
 
 /**
  * Validate extra arguments provided at runtime.
  * Called before executing a command that has allowExtraArgs: true.
  */
-export function validateExtraArgs(commandName: string, extraArgs: readonly string[]): void {
+export function validateExtraArgs(
+  commandName: string,
+  extraArgs: readonly string[],
+  opts?: GuardOptions,
+): void {
   checkShellOperators(commandName, extraArgs);
-  checkDestructiveSubcommand(commandName, extraArgs);
-  checkBlockedSequences(commandName, extraArgs);
+  checkDestructiveSubcommand(commandName, extraArgs, opts);
+  checkBlockedSequences(commandName, extraArgs, opts);
 }
 
 /**
@@ -210,14 +267,53 @@ export function validateExtraArgs(commandName: string, extraArgs: readonly strin
  * configured base args and user-supplied extra args (e.g. base=['tag']
  * combined with extra=['--delete', 'v1'] forms the blocked sequence
  * "tag --delete").
+ *
+ * Also enforces protected-branch rules on the full argument list.
  */
 export function validateCombinedArgs(
   commandName: string,
   baseArgs: readonly string[],
   extraArgs: readonly string[],
+  opts?: GuardOptions,
 ): void {
   // Extra args are already validated individually by validateExtraArgs;
   // here we only need to check blocked sequences across the combined list.
   const combined = [...baseArgs, ...extraArgs];
-  checkBlockedSequences(commandName, combined);
+  checkBlockedSequences(commandName, combined, opts);
+  checkProtectedBranches(commandName, combined, opts);
+}
+
+/**
+ * Build a `GuardOptions` from the config-level `allowedOperations` and
+ * `protectedBranches` arrays.
+ */
+export function buildGuardOptions(
+  allowedOperations?: readonly string[],
+  protectedBranches?: readonly string[],
+): GuardOptions {
+  const allowedSubcommands = new Set<string>();
+  const allowedSequences: [string, string][] = [];
+
+  for (const op of allowedOperations ?? []) {
+    switch (op) {
+      case 'merge':
+      case 'rebase':
+      case 'checkout':
+      case 'switch':
+        allowedSubcommands.add(op);
+        break;
+      case 'branch:delete':
+        allowedSequences.push(['branch', '-d']);
+        allowedSequences.push(['branch', '-D']);
+        allowedSequences.push(['branch', '--delete']);
+        break;
+    }
+  }
+
+  return {
+    allowedSubcommands: allowedSubcommands.size > 0 ? allowedSubcommands : undefined,
+    allowedSequences: allowedSequences.length > 0 ? allowedSequences : undefined,
+    protectedBranches:
+      protectedBranches && protectedBranches.length > 0 ? protectedBranches : undefined,
+  };
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,9 +7,17 @@ export {
   validateCommandArgs,
   validateExtraArgs,
   validateCombinedArgs,
+  buildGuardOptions,
   DestructiveCommandError,
   BLOCKED_SUBCOMMANDS,
   BLOCKED_ARG_SEQUENCES,
   BLOCKED_SHELL_OPERATORS,
 } from './guard.js';
-export type { CommandConfig, CommandsConfig, ExtraArgsSchema, ExtraArgsProperty } from './types.js';
+export type {
+  CommandConfig,
+  CommandsConfig,
+  ExtraArgsSchema,
+  ExtraArgsProperty,
+  AllowedOperation,
+  GuardOptions,
+} from './types.js';

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -10,7 +10,7 @@ import { resolve } from 'node:path';
 import { z } from 'zod';
 
 import { Logger } from '../server/logger.js';
-import { validateCommandArgs, DestructiveCommandError } from './guard.js';
+import { validateCommandArgs, buildGuardOptions, DestructiveCommandError } from './guard.js';
 import { type CommandsConfig, type CommandConfig } from './types.js';
 
 const log = new Logger('config');
@@ -20,17 +20,21 @@ export const DEFAULT_CONFIG_FILENAME = 'commands.config.json';
 
 // ── Zod schemas ────────────────────────────────────────────────────
 
-const ExtraArgsPropertySchema = z.object({
-  type: z.enum(['string', 'number', 'boolean']),
-  description: z.string().optional(),
-  default: z.union([z.string(), z.number(), z.boolean()]).optional(),
-  enum: z.array(z.union([z.string(), z.number(), z.boolean()])).optional(),
-}).strict();
+const ExtraArgsPropertySchema = z
+  .object({
+    type: z.enum(['string', 'number', 'boolean']),
+    description: z.string().optional(),
+    default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+    enum: z.array(z.union([z.string(), z.number(), z.boolean()])).optional(),
+  })
+  .strict();
 
-const ExtraArgsSchemaSchema = z.object({
-  type: z.literal('object'),
-  properties: z.record(z.string(), ExtraArgsPropertySchema),
-}).strict();
+const ExtraArgsSchemaSchema = z
+  .object({
+    type: z.literal('object'),
+    properties: z.record(z.string(), ExtraArgsPropertySchema),
+  })
+  .strict();
 
 const CommandConfigSchema = z
   .object({
@@ -58,10 +62,16 @@ const CommandConfigSchema = z
     },
   );
 
-const CommandsConfigSchema = z.object({
-  $schema: z.string().optional(),
-  commands: z.array(CommandConfigSchema).min(1, 'at least one command must be defined'),
-}).strict();
+const AllowedOperationSchema = z.enum(['merge', 'rebase', 'checkout', 'switch', 'branch:delete']);
+
+const CommandsConfigSchema = z
+  .object({
+    $schema: z.string().optional(),
+    commands: z.array(CommandConfigSchema).min(1, 'at least one command must be defined'),
+    allowedOperations: z.array(AllowedOperationSchema).optional(),
+    protectedBranches: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
 
 // ── Error types ────────────────────────────────────────────────────
 
@@ -102,12 +112,13 @@ function validateUniqueNames(commands: CommandConfig[]): string[] {
   return errors;
 }
 
-/** Run the non-destructive guard on every command. */
-function validateGuard(commands: CommandConfig[]): string[] {
+/** Run the non-destructive guard on every command, respecting allowlists. */
+function validateGuard(commands: CommandConfig[], config: CommandsConfig): string[] {
+  const guardOpts = buildGuardOptions(config.allowedOperations, config.protectedBranches);
   const errors: string[] = [];
   for (const cmd of commands) {
     try {
-      validateCommandArgs(cmd);
+      validateCommandArgs(cmd, guardOpts);
     } catch (err) {
       if (err instanceof DestructiveCommandError) {
         errors.push(err.message);
@@ -129,8 +140,8 @@ function validateDefaultInEnum(commands: CommandConfig[]): string[] {
         if (!prop.enum.includes(prop.default)) {
           errors.push(
             `Command "${cmd.name}": property "${key}" has default ` +
-            `value ${JSON.stringify(prop.default)} which is not in enum ` +
-            `[${prop.enum.map((v) => JSON.stringify(v)).join(', ')}]`,
+              `value ${JSON.stringify(prop.default)} which is not in enum ` +
+              `[${prop.enum.map((v) => JSON.stringify(v)).join(', ')}]`,
           );
         }
       }
@@ -149,9 +160,7 @@ export function parseConfig(raw: unknown): CommandsConfig {
   const result = CommandsConfigSchema.safeParse(raw);
 
   if (!result.success) {
-    const issues = result.error.issues.map(
-      (i) => `${i.path.join('.')}: ${i.message}`,
-    );
+    const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
     throw new ConfigValidationError('Invalid configuration schema', issues);
   }
 
@@ -160,7 +169,7 @@ export function parseConfig(raw: unknown): CommandsConfig {
   // Semantic validations
   const errors: string[] = [
     ...validateUniqueNames(config.commands),
-    ...validateGuard(config.commands),
+    ...validateGuard(config.commands, config),
     ...validateDefaultInEnum(config.commands),
   ];
 
@@ -186,20 +195,14 @@ export async function loadConfig(configPath?: string): Promise<CommandsConfig> {
   try {
     raw = await readFile(filePath, 'utf-8');
   } catch (err) {
-    throw new ConfigLoadError(
-      `Failed to read config file: ${filePath}`,
-      err,
-    );
+    throw new ConfigLoadError(`Failed to read config file: ${filePath}`, err);
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
-    throw new ConfigLoadError(
-      `Failed to parse config file as JSON: ${filePath}`,
-      err,
-    );
+    throw new ConfigLoadError(`Failed to parse config file as JSON: ${filePath}`, err);
   }
 
   return parseConfig(parsed);

--- a/src/config/schema.json
+++ b/src/config/schema.json
@@ -18,6 +18,22 @@
       "items": {
         "$ref": "#/definitions/CommandConfig"
       }
+    },
+    "allowedOperations": {
+      "type": "array",
+      "description": "Operations normally blocked by the non-destructive guard that this configuration explicitly permits.",
+      "items": {
+        "type": "string",
+        "enum": ["merge", "rebase", "checkout", "switch", "branch:delete"]
+      }
+    },
+    "protectedBranches": {
+      "type": "array",
+      "description": "Branch names that must never be the target of a delete operation. Requires 'branch:delete' in allowedOperations.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
   "definitions": {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -35,8 +35,47 @@ export interface CommandConfig {
   extraArgsSchema?: ExtraArgsSchema;
 }
 
+/**
+ * Valid values for the `allowedOperations` config field.
+ *
+ * Each value unblocks a specific git operation that is otherwise forbidden
+ * by the non-destructive guard:
+ *
+ * - `"merge"`          — allows `git merge`
+ * - `"rebase"`         — allows `git rebase`
+ * - `"checkout"`       — allows `git checkout`
+ * - `"switch"`         — allows `git switch`
+ * - `"branch:delete"`  — allows `branch -d / -D / --delete`
+ */
+export type AllowedOperation = 'merge' | 'rebase' | 'checkout' | 'switch' | 'branch:delete';
+
 /** Root shape of `commands.config.json`. */
 export interface CommandsConfig {
   $schema?: string;
   commands: CommandConfig[];
+  /**
+   * Operations that are normally blocked by the non-destructive guard but
+   * should be permitted in this configuration.  Each entry must be one of
+   * the recognised operation identifiers (see {@link AllowedOperation}).
+   */
+  allowedOperations?: AllowedOperation[];
+  /**
+   * Branch names that must never be the target of a `branch -d / -D / --delete`
+   * operation.  Requires `"branch:delete"` in `allowedOperations` to be useful.
+   * Common values: `["main", "master", "develop"]`.
+   */
+  protectedBranches?: string[];
+}
+
+/**
+ * Options forwarded to the non-destructive guard so it can respect
+ * per-config allowlists and protected-branch rules.
+ */
+export interface GuardOptions {
+  /** Subcommands that may bypass the blocked-subcommands check. */
+  allowedSubcommands?: ReadonlySet<string>;
+  /** Arg sequences that may bypass the blocked-sequences check. */
+  allowedSequences?: readonly [string, string][];
+  /** Branch names that must never be deleted. */
+  protectedBranches?: readonly string[];
 }

--- a/src/git/tools.ts
+++ b/src/git/tools.ts
@@ -15,7 +15,12 @@ import { type ToolDefinition } from '../server/registry.js';
 import { ToolExecutionError } from '../server/errors.js';
 import { Logger } from '../server/logger.js';
 import { validateExtraArgs, validateCombinedArgs } from '../config/guard.js';
-import { type CommandConfig, type ExtraArgsSchema, type ExtraArgsProperty } from '../config/types.js';
+import {
+  type CommandConfig,
+  type ExtraArgsSchema,
+  type ExtraArgsProperty,
+  type GuardOptions,
+} from '../config/types.js';
 import { runGit, type RunGitOptions } from './runner.js';
 
 const log = new Logger('git-tools');
@@ -100,10 +105,7 @@ function buildInputSchema(extraArgsSchema?: ExtraArgsSchema): Record<string, z.Z
  * - boolean true → adds the flag name as --key (or specific mapped flag)
  * - string/number → adds as positional or --key value
  */
-function buildExtraCliArgs(
-  config: CommandConfig,
-  inputArgs: Record<string, unknown>,
-): string[] {
+function buildExtraCliArgs(config: CommandConfig, inputArgs: Record<string, unknown>): string[] {
   const extra: string[] = [];
 
   if (!config.extraArgsSchema) return extra;
@@ -153,10 +155,9 @@ function buildExtraCliArgs(
 export function buildToolDefinition(
   config: CommandConfig,
   gitOptions?: RunGitOptions,
+  guardOptions?: GuardOptions,
 ): ToolDefinition {
-  const inputSchema = buildInputSchema(
-    config.allowExtraArgs ? config.extraArgsSchema : undefined,
-  );
+  const inputSchema = buildInputSchema(config.allowExtraArgs ? config.extraArgsSchema : undefined);
 
   return {
     name: config.name,
@@ -174,8 +175,8 @@ export function buildToolDefinition(
         // Validate extra args individually and combined with base args
         if (extraArgs.length > 0) {
           try {
-            validateExtraArgs(config.name, extraArgs);
-            validateCombinedArgs(config.name, config.args, extraArgs);
+            validateExtraArgs(config.name, extraArgs, guardOptions);
+            validateCombinedArgs(config.name, config.args, extraArgs, guardOptions);
           } catch (err) {
             throw new ToolExecutionError(
               config.name,
@@ -213,7 +214,8 @@ export function buildToolDefinition(
 export function buildTools(
   commands: readonly CommandConfig[],
   gitOptions?: RunGitOptions,
+  guardOptions?: GuardOptions,
 ): ToolDefinition[] {
   log.info(`Building ${commands.length} tool(s) from config`);
-  return commands.map((cmd) => buildToolDefinition(cmd, gitOptions));
+  return commands.map((cmd) => buildToolDefinition(cmd, gitOptions, guardOptions));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
-import { loadConfig, ConfigLoadError, ConfigValidationError } from './config/index.js';
-import { type CommandConfig } from './config/types.js';
+import {
+  loadConfig,
+  buildGuardOptions,
+  ConfigLoadError,
+  ConfigValidationError,
+} from './config/index.js';
+import { type CommandConfig, type GuardOptions } from './config/types.js';
 import { buildTools } from './git/index.js';
 import { Logger } from './server/logger.js';
 import { ToolRegistry } from './server/registry.js';
@@ -72,9 +77,11 @@ export async function main(): Promise<void> {
   // Load command configuration (optional — server starts without config)
   const configPath = process.env.GITPRIDE_CONFIG;
   let commands: CommandConfig[] = [];
+  let guardOptions: GuardOptions = {};
   try {
     const config = await loadConfig(configPath);
     commands = config.commands;
+    guardOptions = buildGuardOptions(config.allowedOperations, config.protectedBranches);
     log.info(`Loaded ${config.commands.length} command(s) from config`);
   } catch (err) {
     if (err instanceof ConfigLoadError && !configPath) {
@@ -94,7 +101,7 @@ export async function main(): Promise<void> {
 
   // Build and register git command tools from config
   if (commands.length > 0) {
-    const tools = buildTools(commands);
+    const tools = buildTools(commands, undefined, guardOptions);
     registry.registerAll(tools);
     log.info(`Registered ${tools.length} git tool(s)`);
   }

--- a/tests/config/code-review-workflow.test.ts
+++ b/tests/config/code-review-workflow.test.ts
@@ -1,0 +1,568 @@
+/**
+ * Tests for allowedOperations, protectedBranches, and the code review
+ * workflow configuration (issue #44).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writeFile, rm, mkdir, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+
+import {
+  validateCommandArgs,
+  validateExtraArgs,
+  validateCombinedArgs,
+  buildGuardOptions,
+  DestructiveCommandError,
+} from '../../src/config/guard.js';
+import { parseConfig, loadConfig, ConfigValidationError } from '../../src/config/loader.js';
+import { buildToolDefinition } from '../../src/git/tools.js';
+import { type CommandConfig } from '../../src/config/types.js';
+
+// Suppress logger output during tests
+vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+function makeCommand(overrides: Partial<CommandConfig> = {}): CommandConfig {
+  return {
+    name: 'test_cmd',
+    description: 'Test command',
+    command: 'git',
+    args: ['status'],
+    allowExtraArgs: false,
+    ...overrides,
+  };
+}
+
+// ── buildGuardOptions ──────────────────────────────────────────────
+
+describe('buildGuardOptions', () => {
+  it('should return empty options when no operations specified', () => {
+    const opts = buildGuardOptions(undefined, undefined);
+    expect(opts.allowedSubcommands).toBeUndefined();
+    expect(opts.allowedSequences).toBeUndefined();
+    expect(opts.protectedBranches).toBeUndefined();
+  });
+
+  it('should return empty options for empty arrays', () => {
+    const opts = buildGuardOptions([], []);
+    expect(opts.allowedSubcommands).toBeUndefined();
+    expect(opts.allowedSequences).toBeUndefined();
+    expect(opts.protectedBranches).toBeUndefined();
+  });
+
+  it('should build allowed subcommands for merge/rebase/checkout/switch', () => {
+    const opts = buildGuardOptions(['merge', 'rebase', 'checkout', 'switch']);
+    expect(opts.allowedSubcommands).toBeDefined();
+    expect(opts.allowedSubcommands!.has('merge')).toBe(true);
+    expect(opts.allowedSubcommands!.has('rebase')).toBe(true);
+    expect(opts.allowedSubcommands!.has('checkout')).toBe(true);
+    expect(opts.allowedSubcommands!.has('switch')).toBe(true);
+  });
+
+  it('should build allowed sequences for branch:delete', () => {
+    const opts = buildGuardOptions(['branch:delete']);
+    expect(opts.allowedSequences).toBeDefined();
+    expect(opts.allowedSequences).toEqual(
+      expect.arrayContaining([
+        ['branch', '-d'],
+        ['branch', '-D'],
+        ['branch', '--delete'],
+      ]),
+    );
+  });
+
+  it('should set protectedBranches from input', () => {
+    const opts = buildGuardOptions([], ['main', 'master']);
+    expect(opts.protectedBranches).toEqual(['main', 'master']);
+  });
+
+  it('should handle combined operations and protected branches', () => {
+    const opts = buildGuardOptions(['merge', 'branch:delete'], ['main', 'develop']);
+    expect(opts.allowedSubcommands!.has('merge')).toBe(true);
+    expect(opts.allowedSequences).toHaveLength(3);
+    expect(opts.protectedBranches).toEqual(['main', 'develop']);
+  });
+});
+
+// ── Guard with allowedOperations ───────────────────────────────────
+
+describe('validateCommandArgs with GuardOptions', () => {
+  it('should allow merge when opted in', () => {
+    const opts = buildGuardOptions(['merge']);
+    expect(() =>
+      validateCommandArgs(makeCommand({ args: ['merge', '--no-edit'] }), opts),
+    ).not.toThrow();
+  });
+
+  it('should allow rebase when opted in', () => {
+    const opts = buildGuardOptions(['rebase']);
+    expect(() => validateCommandArgs(makeCommand({ args: ['rebase'] }), opts)).not.toThrow();
+  });
+
+  it('should allow checkout when opted in', () => {
+    const opts = buildGuardOptions(['checkout']);
+    expect(() => validateCommandArgs(makeCommand({ args: ['checkout'] }), opts)).not.toThrow();
+  });
+
+  it('should allow switch when opted in', () => {
+    const opts = buildGuardOptions(['switch']);
+    expect(() => validateCommandArgs(makeCommand({ args: ['switch'] }), opts)).not.toThrow();
+  });
+
+  it('should allow branch -d when branch:delete opted in', () => {
+    const opts = buildGuardOptions(['branch:delete']);
+    expect(() => validateCommandArgs(makeCommand({ args: ['branch', '-d'] }), opts)).not.toThrow();
+  });
+
+  it('should allow branch --delete when branch:delete opted in', () => {
+    const opts = buildGuardOptions(['branch:delete']);
+    expect(() =>
+      validateCommandArgs(makeCommand({ args: ['branch', '--delete'] }), opts),
+    ).not.toThrow();
+  });
+
+  it('should allow branch -D when branch:delete opted in', () => {
+    const opts = buildGuardOptions(['branch:delete']);
+    expect(() => validateCommandArgs(makeCommand({ args: ['branch', '-D'] }), opts)).not.toThrow();
+  });
+
+  it('should still block merge without opt-in', () => {
+    expect(() => validateCommandArgs(makeCommand({ args: ['merge'] }))).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should still block push even with all operations allowed', () => {
+    const opts = buildGuardOptions(['merge', 'rebase', 'checkout', 'switch', 'branch:delete']);
+    expect(() => validateCommandArgs(makeCommand({ args: ['push'] }), opts)).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should still block commit even with operations allowed', () => {
+    const opts = buildGuardOptions(['merge', 'rebase']);
+    expect(() => validateCommandArgs(makeCommand({ args: ['commit'] }), opts)).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should still block branch -m even with branch:delete allowed', () => {
+    const opts = buildGuardOptions(['branch:delete']);
+    expect(() => validateCommandArgs(makeCommand({ args: ['branch', '-m'] }), opts)).toThrow(
+      DestructiveCommandError,
+    );
+  });
+
+  it('should still block tag --delete even with branch:delete allowed', () => {
+    const opts = buildGuardOptions(['branch:delete']);
+    expect(() => validateCommandArgs(makeCommand({ args: ['tag', '--delete'] }), opts)).toThrow(
+      DestructiveCommandError,
+    );
+  });
+});
+
+// ── Protected branches ─────────────────────────────────────────────
+
+describe('validateCombinedArgs with protectedBranches', () => {
+  const opts = buildGuardOptions(['branch:delete'], ['main', 'master', 'develop']);
+
+  it('should block deleting a protected branch', () => {
+    expect(() =>
+      validateCombinedArgs('git_branch_delete', ['branch', '-d'], ['main'], opts),
+    ).toThrow(DestructiveCommandError);
+    expect(() =>
+      validateCombinedArgs('git_branch_delete', ['branch', '-d'], ['main'], opts),
+    ).toThrow(/protected branch "main"/);
+  });
+
+  it('should block deleting master', () => {
+    expect(() =>
+      validateCombinedArgs('git_branch_delete', ['branch', '-d'], ['master'], opts),
+    ).toThrow(/protected branch "master"/);
+  });
+
+  it('should block deleting develop', () => {
+    expect(() =>
+      validateCombinedArgs('git_branch_delete', ['branch', '--delete'], ['develop'], opts),
+    ).toThrow(/protected branch "develop"/);
+  });
+
+  it('should block force-deleting a protected branch', () => {
+    expect(() =>
+      validateCombinedArgs('git_branch_delete', ['branch', '-D'], ['main'], opts),
+    ).toThrow(/protected branch "main"/);
+  });
+
+  it('should allow deleting a non-protected branch', () => {
+    expect(() =>
+      validateCombinedArgs('git_branch_delete', ['branch', '-d'], ['feature/my-branch'], opts),
+    ).not.toThrow();
+  });
+
+  it('should allow operations on branches when no delete flag present', () => {
+    expect(() => validateCombinedArgs('git_branch', ['branch'], ['main'], opts)).not.toThrow();
+  });
+});
+
+describe('validateExtraArgs with GuardOptions', () => {
+  it('should allow merge subcommand in extra args when opted in', () => {
+    const opts = buildGuardOptions(['merge']);
+    expect(() => validateExtraArgs('git_run', ['merge'], opts)).not.toThrow();
+  });
+
+  it('should block merge subcommand in extra args without opt-in', () => {
+    expect(() => validateExtraArgs('git_run', ['merge'])).toThrow(DestructiveCommandError);
+  });
+});
+
+// ── Config parsing with allowedOperations ──────────────────────────
+
+describe('parseConfig with allowedOperations', () => {
+  it('should accept config with allowedOperations and write commands', () => {
+    const config = {
+      allowedOperations: ['merge', 'rebase'],
+      commands: [
+        {
+          name: 'git_merge',
+          description: 'Merge a branch',
+          command: 'git',
+          args: ['merge', '--no-edit'],
+          allowExtraArgs: true,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              branch: { type: 'string', description: 'Branch to merge' },
+            },
+          },
+        },
+        {
+          name: 'git_rebase',
+          description: 'Rebase onto branch',
+          command: 'git',
+          args: ['rebase'],
+          allowExtraArgs: true,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              onto: { type: 'string', description: 'Branch to rebase onto' },
+            },
+          },
+        },
+      ],
+    };
+    const result = parseConfig(config);
+    expect(result.commands).toHaveLength(2);
+    expect(result.allowedOperations).toEqual(['merge', 'rebase']);
+  });
+
+  it('should reject merge command without allowedOperations', () => {
+    const config = {
+      commands: [
+        {
+          name: 'git_merge',
+          description: 'Merge',
+          command: 'git',
+          args: ['merge'],
+          allowExtraArgs: false,
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).toThrow(ConfigValidationError);
+  });
+
+  it('should accept config with protectedBranches', () => {
+    const config = {
+      allowedOperations: ['branch:delete'],
+      protectedBranches: ['main', 'master'],
+      commands: [
+        {
+          name: 'git_branch_delete',
+          description: 'Delete branch',
+          command: 'git',
+          args: ['branch', '-d'],
+          allowExtraArgs: true,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              branch: { type: 'string', description: 'Branch to delete' },
+            },
+          },
+        },
+      ],
+    };
+    const result = parseConfig(config);
+    expect(result.protectedBranches).toEqual(['main', 'master']);
+  });
+
+  it('should reject invalid allowedOperations values', () => {
+    const config = {
+      allowedOperations: ['push'],
+      commands: [
+        {
+          name: 'git_status',
+          description: 'Status',
+          command: 'git',
+          args: ['status'],
+          allowExtraArgs: false,
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).toThrow(ConfigValidationError);
+  });
+
+  it('should accept all valid allowedOperations values', () => {
+    const config = {
+      allowedOperations: ['merge', 'rebase', 'checkout', 'switch', 'branch:delete'],
+      protectedBranches: ['main'],
+      commands: [
+        {
+          name: 'git_status',
+          description: 'Status',
+          command: 'git',
+          args: ['status'],
+          allowExtraArgs: false,
+        },
+      ],
+    };
+    expect(() => parseConfig(config)).not.toThrow();
+  });
+
+  it('should work without allowedOperations (backward compat)', () => {
+    const config = {
+      commands: [
+        {
+          name: 'git_status',
+          description: 'Status',
+          command: 'git',
+          args: ['status'],
+          allowExtraArgs: false,
+        },
+      ],
+    };
+    const result = parseConfig(config);
+    expect(result.allowedOperations).toBeUndefined();
+    expect(result.protectedBranches).toBeUndefined();
+  });
+});
+
+// ── loadConfig with code-review-workflow example ───────────────────
+
+describe('loadConfig with code-review-workflow example', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `gitpride-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should load config with allowedOperations from file', async () => {
+    const config = {
+      allowedOperations: ['merge', 'branch:delete'],
+      protectedBranches: ['main'],
+      commands: [
+        {
+          name: 'git_merge',
+          description: 'Merge branch',
+          command: 'git',
+          args: ['merge', '--no-edit'],
+          allowExtraArgs: true,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              branch: { type: 'string', description: 'Branch' },
+            },
+          },
+        },
+        {
+          name: 'git_branch_delete',
+          description: 'Delete branch',
+          command: 'git',
+          args: ['branch', '-d'],
+          allowExtraArgs: true,
+          extraArgsSchema: {
+            type: 'object',
+            properties: {
+              branch: { type: 'string', description: 'Branch' },
+            },
+          },
+        },
+      ],
+    };
+    const configPath = join(tempDir, 'commands.config.json');
+    await writeFile(configPath, JSON.stringify(config));
+
+    const result = await loadConfig(configPath);
+    expect(result.commands).toHaveLength(2);
+    expect(result.allowedOperations).toEqual(['merge', 'branch:delete']);
+    expect(result.protectedBranches).toEqual(['main']);
+  });
+});
+
+// ── Tool execution with GuardOptions ───────────────────────────────
+
+describe('buildToolDefinition with GuardOptions (integration)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'gitpride-cr-'));
+    execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+    execSync('git config user.email "test@test.com"', { cwd: tempDir, stdio: 'ignore' });
+    execSync('git config user.name "Test"', { cwd: tempDir, stdio: 'ignore' });
+    await writeFile(join(tempDir, 'file.txt'), 'initial');
+    execSync('git add . && git commit -m "initial"', { cwd: tempDir, stdio: 'ignore' });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('git_merge tool', () => {
+    it('should merge a feature branch', async () => {
+      execSync('git checkout -b feature/test', { cwd: tempDir, stdio: 'ignore' });
+      await writeFile(join(tempDir, 'feature.txt'), 'feature content');
+      execSync('git add . && git commit -m "feature commit"', { cwd: tempDir, stdio: 'ignore' });
+      execSync('git checkout master 2>/dev/null || git checkout main', {
+        cwd: tempDir,
+        stdio: 'ignore',
+      });
+
+      const guardOpts = buildGuardOptions(['merge']);
+      const mergeConfig: CommandConfig = {
+        name: 'git_merge',
+        description: 'Merge a branch',
+        command: 'git',
+        args: ['merge', '--no-edit'],
+        allowExtraArgs: true,
+        extraArgsSchema: {
+          type: 'object',
+          properties: {
+            branch: { type: 'string', description: 'Branch to merge' },
+          },
+        },
+      };
+
+      const tool = buildToolDefinition(mergeConfig, { cwd: tempDir }, guardOpts);
+      const result = await tool.handler({ branch: 'feature/test' });
+      expect(result.isError).toBeUndefined();
+    });
+  });
+
+  describe('git_branch_delete tool', () => {
+    it('should delete a feature branch', async () => {
+      execSync('git checkout -b feature/to-delete', { cwd: tempDir, stdio: 'ignore' });
+      execSync('git checkout master 2>/dev/null || git checkout main', {
+        cwd: tempDir,
+        stdio: 'ignore',
+      });
+
+      const guardOpts = buildGuardOptions(['branch:delete'], ['main', 'master']);
+      const deleteConfig: CommandConfig = {
+        name: 'git_branch_delete',
+        description: 'Delete branch',
+        command: 'git',
+        args: ['branch', '-d'],
+        allowExtraArgs: true,
+        extraArgsSchema: {
+          type: 'object',
+          properties: {
+            branch: { type: 'string', description: 'Branch to delete' },
+          },
+        },
+      };
+
+      const tool = buildToolDefinition(deleteConfig, { cwd: tempDir }, guardOpts);
+      const result = await tool.handler({ branch: 'feature/to-delete' });
+      expect(result.isError).toBeUndefined();
+      expect((result.content[0] as { text: string }).text).toContain('feature/to-delete');
+    });
+
+    it('should block deleting a protected branch at runtime', async () => {
+      const guardOpts = buildGuardOptions(['branch:delete'], ['main', 'master']);
+      const deleteConfig: CommandConfig = {
+        name: 'git_branch_delete',
+        description: 'Delete branch',
+        command: 'git',
+        args: ['branch', '-d'],
+        allowExtraArgs: true,
+        extraArgsSchema: {
+          type: 'object',
+          properties: {
+            branch: { type: 'string', description: 'Branch to delete' },
+          },
+        },
+      };
+
+      const tool = buildToolDefinition(deleteConfig, { cwd: tempDir }, guardOpts);
+      await expect(tool.handler({ branch: 'main' })).rejects.toThrow(/protected branch "main"/);
+    });
+  });
+
+  describe('git_checkout tool', () => {
+    it('should switch to a branch', async () => {
+      execSync('git checkout -b feature/switch-test', { cwd: tempDir, stdio: 'ignore' });
+      execSync('git checkout master 2>/dev/null || git checkout main', {
+        cwd: tempDir,
+        stdio: 'ignore',
+      });
+
+      const guardOpts = buildGuardOptions(['checkout']);
+      const checkoutConfig: CommandConfig = {
+        name: 'git_checkout',
+        description: 'Switch branch',
+        command: 'git',
+        args: ['checkout'],
+        allowExtraArgs: true,
+        extraArgsSchema: {
+          type: 'object',
+          properties: {
+            branch: { type: 'string', description: 'Branch to switch to' },
+          },
+        },
+      };
+
+      const tool = buildToolDefinition(checkoutConfig, { cwd: tempDir }, guardOpts);
+      const result = await tool.handler({ branch: 'feature/switch-test' });
+      expect(result.isError).toBeUndefined();
+    });
+  });
+
+  describe('git_rebase tool', () => {
+    it('should rebase a branch', async () => {
+      // Create divergent history
+      execSync('git checkout -b feature/rebase-test', { cwd: tempDir, stdio: 'ignore' });
+      await writeFile(join(tempDir, 'feature-rebase.txt'), 'rebase content');
+      execSync('git add . && git commit -m "feature for rebase"', {
+        cwd: tempDir,
+        stdio: 'ignore',
+      });
+
+      const guardOpts = buildGuardOptions(['rebase']);
+      const rebaseConfig: CommandConfig = {
+        name: 'git_rebase',
+        description: 'Rebase branch',
+        command: 'git',
+        args: ['rebase'],
+        allowExtraArgs: true,
+        extraArgsSchema: {
+          type: 'object',
+          properties: {
+            onto: { type: 'string', description: 'Branch to rebase onto' },
+          },
+        },
+      };
+
+      const defaultBranch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: tempDir })
+        .toString()
+        .trim();
+      // Already on feature branch, rebase onto itself is a no-op, which is fine for the test
+      const tool = buildToolDefinition(rebaseConfig, { cwd: tempDir }, guardOpts);
+      const result = await tool.handler({ onto: defaultBranch });
+      expect(result.isError).toBeUndefined();
+    });
+  });
+});

--- a/tests/config/guard.test.ts
+++ b/tests/config/guard.test.ts
@@ -39,39 +39,35 @@ describe('validateCommandArgs', () => {
   });
 
   it('should block "tag --delete" sequence', () => {
-    expect(() =>
-      validateCommandArgs(makeCommand({ args: ['tag', '--delete'] })),
-    ).toThrow(DestructiveCommandError);
+    expect(() => validateCommandArgs(makeCommand({ args: ['tag', '--delete'] }))).toThrow(
+      DestructiveCommandError,
+    );
   });
 
   it('should block "tag -d" sequence', () => {
-    expect(() =>
-      validateCommandArgs(makeCommand({ args: ['tag', '-d'] })),
-    ).toThrow(DestructiveCommandError);
+    expect(() => validateCommandArgs(makeCommand({ args: ['tag', '-d'] }))).toThrow(
+      DestructiveCommandError,
+    );
   });
 
   it('should block "branch -D" sequence', () => {
-    expect(() =>
-      validateCommandArgs(makeCommand({ args: ['branch', '-D'] })),
-    ).toThrow(DestructiveCommandError);
+    expect(() => validateCommandArgs(makeCommand({ args: ['branch', '-D'] }))).toThrow(
+      DestructiveCommandError,
+    );
   });
 
   it('should block "branch --delete" sequence', () => {
-    expect(() =>
-      validateCommandArgs(makeCommand({ args: ['branch', '--delete'] })),
-    ).toThrow(DestructiveCommandError);
+    expect(() => validateCommandArgs(makeCommand({ args: ['branch', '--delete'] }))).toThrow(
+      DestructiveCommandError,
+    );
   });
 
   it('should allow "branch" without -D', () => {
-    expect(() =>
-      validateCommandArgs(makeCommand({ args: ['branch', '-a'] })),
-    ).not.toThrow();
+    expect(() => validateCommandArgs(makeCommand({ args: ['branch', '-a'] }))).not.toThrow();
   });
 
   it('should allow "tag" without --delete', () => {
-    expect(() =>
-      validateCommandArgs(makeCommand({ args: ['tag', '-l'] })),
-    ).not.toThrow();
+    expect(() => validateCommandArgs(makeCommand({ args: ['tag', '-l'] }))).not.toThrow();
   });
 
   it('should block shell operators as exact tokens', () => {
@@ -84,9 +80,9 @@ describe('validateCommandArgs', () => {
   });
 
   it('should block embedded shell operators', () => {
-    expect(() =>
-      validateCommandArgs(makeCommand({ args: ['log;rm', '-rf'] })),
-    ).toThrow(DestructiveCommandError);
+    expect(() => validateCommandArgs(makeCommand({ args: ['log;rm', '-rf'] }))).toThrow(
+      DestructiveCommandError,
+    );
   });
 
   it('should include the command name in the error message', () => {
@@ -101,9 +97,7 @@ describe('validateCommandArgs', () => {
   });
 
   it('should accept commands with flags before the subcommand', () => {
-    expect(() =>
-      validateCommandArgs(makeCommand({ args: ['-C', '/tmp', 'log'] })),
-    ).not.toThrow();
+    expect(() => validateCommandArgs(makeCommand({ args: ['-C', '/tmp', 'log'] }))).not.toThrow();
   });
 });
 
@@ -123,9 +117,7 @@ describe('validateExtraArgs', () => {
   });
 
   it('should block redirect operators in extra args', () => {
-    expect(() => validateExtraArgs('git_log', ['>', '/tmp/out'])).toThrow(
-      DestructiveCommandError,
-    );
+    expect(() => validateExtraArgs('git_log', ['>', '/tmp/out'])).toThrow(DestructiveCommandError);
   });
 });
 
@@ -256,9 +248,7 @@ describe('newly blocked arg sequences (issue #39)', () => {
 
   it('should include all expected sequences in BLOCKED_ARG_SEQUENCES', () => {
     for (const [first, second] of newSequences) {
-      const found = BLOCKED_ARG_SEQUENCES.some(
-        ([f, s]) => f === first && s === second,
-      );
+      const found = BLOCKED_ARG_SEQUENCES.some(([f, s]) => f === first && s === second);
       expect(found, `expected [${first}, ${second}] in BLOCKED_ARG_SEQUENCES`).toBe(true);
     }
   });


### PR DESCRIPTION
## Summary

Add config-level support for selectively unblocking git operations needed for code review workflows, while maintaining safety through protected branch rules.

### New Features

- **`allowedOperations`** config field: Opt-in to specific write operations (`merge`, `rebase`, `checkout`, `switch`, `branch:delete`)
- **`protectedBranches`** config field: Prevent accidental deletion of base branches (e.g. `main`, `master`, `develop`)
- **New example config**: `examples/code-review-workflow.config.json` — ready-to-use config with merge, rebase, checkout, and branch delete tools

### How It Works

The non-destructive guard now accepts optional `GuardOptions` that allow specific operations to bypass the block list. Protected branches are still enforced even when `branch:delete` is allowed — any attempt to delete a protected branch is rejected at runtime.

### Files Changed

- `src/config/types.ts` — New `AllowedOperation`, `GuardOptions` types
- `src/config/guard.ts` — Updated validation to respect allowlists + protected branches
- `src/config/loader.ts` — Parse new config fields
- `src/config/schema.json` — Schema for new fields
- `src/git/tools.ts` — Thread `GuardOptions` to runtime validation
- `src/index.ts` — Build guard options from loaded config
- `docs/configuration.md` — Documentation for new features
- `tests/config/code-review-workflow.test.ts` — 38 new tests

### Testing

All 208 tests pass (170 existing + 38 new).

Fixes #44