### PR TITLE
fix: enforce protected branch checks in validators

### DIFF
--- a/src/config/guard.ts
+++ b/src/config/guard.ts
@@ -244,6 +244,7 @@ export function validateCommandArgs(command: CommandConfig, opts?: GuardOptions)
   checkShellOperators(command.name, command.args);
   checkDestructiveSubcommand(command.name, command.args, opts);
   checkBlockedSequences(command.name, command.args, opts);
+  checkProtectedBranches(command.name, command.args, opts);
 }
 
 /**
@@ -258,6 +259,7 @@ export function validateExtraArgs(
   checkShellOperators(commandName, extraArgs);
   checkDestructiveSubcommand(commandName, extraArgs, opts);
   checkBlockedSequences(commandName, extraArgs, opts);
+  checkProtectedBranches(commandName, extraArgs, opts);
 }
 
 /**

--- a/tests/config/guard.test.ts
+++ b/tests/config/guard.test.ts
@@ -3,6 +3,7 @@ import {
   validateCommandArgs,
   validateExtraArgs,
   validateCombinedArgs,
+  buildGuardOptions,
   DestructiveCommandError,
   BLOCKED_SUBCOMMANDS,
   BLOCKED_ARG_SEQUENCES,
@@ -251,5 +252,62 @@ describe('newly blocked arg sequences (issue #39)', () => {
       const found = BLOCKED_ARG_SEQUENCES.some(([f, s]) => f === first && s === second);
       expect(found, `expected [${first}, ${second}] in BLOCKED_ARG_SEQUENCES`).toBe(true);
     }
+  });
+});
+
+describe('protected branches in validateCommandArgs', () => {
+  it('should block deletion of a protected branch in base args', () => {
+    const opts = buildGuardOptions(['branch:delete'], ['main', 'master']);
+    expect(() =>
+      validateCommandArgs(makeCommand({ args: ['branch', '-d', 'main'] }), opts),
+    ).toThrow(DestructiveCommandError);
+  });
+
+  it('should block force-deletion of a protected branch in base args', () => {
+    const opts = buildGuardOptions(['branch:delete'], ['main']);
+    expect(() =>
+      validateCommandArgs(makeCommand({ args: ['branch', '-D', 'main'] }), opts),
+    ).toThrow(DestructiveCommandError);
+  });
+
+  it('should block --delete of a protected branch in base args', () => {
+    const opts = buildGuardOptions(['branch:delete'], ['develop']);
+    expect(() =>
+      validateCommandArgs(makeCommand({ args: ['branch', '--delete', 'develop'] }), opts),
+    ).toThrow(DestructiveCommandError);
+  });
+
+  it('should allow deletion of a non-protected branch in base args', () => {
+    const opts = buildGuardOptions(['branch:delete'], ['main', 'master']);
+    expect(() =>
+      validateCommandArgs(makeCommand({ args: ['branch', '-d', 'feature/foo'] }), opts),
+    ).not.toThrow();
+  });
+
+  it('should include the protected branch name in the error', () => {
+    const opts = buildGuardOptions(['branch:delete'], ['main']);
+    try {
+      validateCommandArgs(makeCommand({ args: ['branch', '-d', 'main'] }), opts);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DestructiveCommandError);
+      expect((err as DestructiveCommandError).message).toContain('main');
+    }
+  });
+});
+
+describe('protected branches in validateExtraArgs', () => {
+  it('should block deletion of a protected branch in extra args', () => {
+    const opts = buildGuardOptions(['branch:delete'], ['main']);
+    expect(() =>
+      validateExtraArgs('git_branch', ['branch', '-d', 'main'], opts),
+    ).toThrow(DestructiveCommandError);
+  });
+
+  it('should allow deletion of a non-protected branch in extra args', () => {
+    const opts = buildGuardOptions(['branch:delete'], ['main']);
+    expect(() =>
+      validateExtraArgs('git_branch', ['branch', '-d', 'feature/bar'], opts),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
Summary:\n- enforce protected branch checks in validateCommandArgs\n- enforce protected branch checks in validateExtraArgs\n- add tests for protected branch deletion handling\n\nTesting:\n- updated tests in tests/config/guard.test.ts